### PR TITLE
Reduce disk sizes

### DIFF
--- a/zeebe-benchmark/values.yaml
+++ b/zeebe-benchmark/values.yaml
@@ -116,7 +116,7 @@ camunda-platform:
     # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     pvcAccessMode: ["ReadWriteOnce"]
     # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
-    pvcSize: 128Gi
+    pvcSize: 32Gi
     # PvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD.
     pvcStorageClassName: ssd
 
@@ -205,7 +205,7 @@ camunda-platform:
       storageClassName: "ssd"
       resources:
         requests:
-          storage: 64Gi
+          storage: 16Gi
 
     esJavaOpts: "-Xmx3g -Xms3g"
 


### PR DESCRIPTION
We reduced recently the resources and workload of the benchmarks, but not the disk sizes. This PR reduces the disk size by 1/4. The disk size for Zeebe is now similar to the cluster plan G3-S, and it is still serving a similar workload. The elasticsearch is a bit higher then for G3-S, since we have no auto resizing and we need a bit bigger disk for our workload.

![clusterplan](https://user-images.githubusercontent.com/2758593/209290266-661d1b88-64b9-49df-b91c-e36cc7d5696f.png)


This should help to reduce further our costs of running benchmarks since right now [disk are a main factor in our costs.](https://console.cloud.google.com/billing/01704C-DE13F5-D69A2F/reports;chartType=STACKED_BAR;timeRange=LAST_30_DAYS;grouping=GROUP_BY_SKU;projects=zeebe-io?project=zeebe-io&organizationId=252201914815)

----

Details:

| | New Disk sizes | Weekly | Comment
|-|----------------------|------------|----------|
| General | ![general](https://user-images.githubusercontent.com/2758593/209289247-25fada93-3510-42ba-bfff-83371057dc0d.png) |![general-weekly](https://user-images.githubusercontent.com/2758593/209289250-db9d95f3-4462-44c3-9422-9ecf14070399.png) | The throughput looks quite similar, we can see with the new resources we have less backpressure but this is just a snapshot in time |
| Latency | ![latency](https://user-images.githubusercontent.com/2758593/209289412-fa9fa1f3-a885-49ff-9197-6266e6755bf7.png) | ![latency-weekly](https://user-images.githubusercontent.com/2758593/209289414-575cc1f0-3445-44d3-a013-4ae8af07fd6a.png) | The latency looks quite similar, maybe with smaller disks a bit higher in the commit latency but looks negligible (for now). |
| IO | ![io](https://user-images.githubusercontent.com/2758593/209289548-598361fc-bd88-445e-b716-4603da0a4b09.png) | ![io-weekly](https://user-images.githubusercontent.com/2758593/209289552-21ad3252-9424-411e-9668-41542691137a.png) | Here I can see almost no difference. We can see that with the new disk size, we still only need ~15% of the disk size.|
| Elastic | ![elastic](https://user-images.githubusercontent.com/2758593/209290302-ea8de5d9-4eb2-440a-9357-7ed8467e55af.png) | ![elastic-weekly](https://user-images.githubusercontent.com/2758593/209290306-288641c5-7f3d-4a70-81fc-a7db3945f217.png) | We can see with the reduced disk size, we use much more of the disk and I feel we can't really reduce the size more. But I guess by factor 1/4 is already enough. |
| Throttling writes IOPs | ![throtteling-write](https://user-images.githubusercontent.com/2758593/209290212-4259dd35-a6d5-4c2f-a0e7-681bbec8f090.png) | ![throtteling-write-weekly](https://user-images.githubusercontent.com/2758593/209293142-c9f2231a-904f-4fcc-9127-e825081ba8e1.png) | I first thought the throttling is only on the new benchmark but it looks like we have a similar throttling on our weekly benchmark, so I think this is fine then. [Seems the metrics also have been deprecated.](https://cloud.google.com/compute/docs/disks/review-disk-metrics#throttling_metrics) | 


I think it makes sense to reduce the disk size to that size since we use the same on prod, and as we can see on the disk usage actually our automated disk size scaler will never be triggered since we always have the same disk usage (except of course elastic is down).





