### PR TITLE
fix: download pyroscope from alpine container for TLS verification

### DIFF
--- a/profiling.yaml
+++ b/profiling.yaml
@@ -16,7 +16,7 @@ camunda-platform:
         mountPath: /pyroscope
     extraInitContainers:
       - name: pyroscope
-        image: busybox
+        image: alpine
         command: ['wget', 'https://github.com/pyroscope-io/pyroscope-java/releases/latest/download/pyroscope.jar', '-O', '/pyroscope/pyroscope.jar']
         volumeMounts:
         - name: pyroscope


### PR DESCRIPTION
Using the busybox wget was a bad idea because there's no TLS verification and connections can fail when there are multiple handshakes involved: https://github.com/docker-library/busybox/issues/134

Here we switch to alpine which should not have issues downloading pyroscope over TLS.