### PR TITLE
Increase throughput target to 150 PI/s

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -10,7 +10,7 @@ worker:
 
 starter:
   replicas: 1
-  rate: 75
+  rate: 150
 
 publisher:
   replicas: 0


### PR DESCRIPTION
With the recent changes, our old throughput target of 75 PI/s wasn't stressing the system anymore:

![image](https://user-images.githubusercontent.com/1379753/213208988-63c31859-7eb4-4771-aa50-571960804b5c.png)

A recent run of main targeting 150PI/s results in ~130PI/s and decent backpressure: 
![image](https://user-images.githubusercontent.com/1379753/213213633-d2edd6ee-4484-4b92-a0f7-1b006d0d1b32.png)
