### PR TITLE
feat: set zeebe config via values

### DIFF
--- a/charts/zeebe-benchmark/templates/zeebe-config.yaml
+++ b/charts/zeebe-benchmark/templates/zeebe-config.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: zeebe-config
+  labels: {{- include "zeebe-benchmark.labels" . | nindent 4 }}
+data: 
+  application.yml: | {{ .Values.zeebe.config | toYaml | nindent 4 }}

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -24,6 +24,9 @@ leaderBalancing:
   enabled: true
   schedule: "*/15 * * * *"
 
+zeebe:
+  config: {}
+
 camunda-platform:
   enabled: true
   global:
@@ -61,6 +64,18 @@ camunda-platform:
       -XX:HeapDumpPath=/usr/local/zeebe/data
       -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
       -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M
+
+    # Zeebe config
+    extraVolumes:
+      - name: zeebe-config
+        configMap:
+          name: zeebe-config
+          defaultMode: 0754
+
+    extraVolumeMounts:
+      - name: zeebe-config
+        mountPath: /usr/local/zeebe/config/application.yaml
+        subPath: application.yml
 
     # Environment variables
     env:


### PR DESCRIPTION
Allows 
```shell
helm install os-test-cfg ./charts/zeebe-benchmark --set zeebe.config.zeebe.broker.experimental.maxAppendsPerFollower=16
```

Results in a mounted config map like 
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: zeebe-config
  labels:
    helm.sh/chart: zeebe-benchmark-0.1.3
    app.kubernetes.io/name: zeebe-benchmark
    app.kubernetes.io/instance: os-test-cfg
    app.kubernetes.io/version: "8.1.2"
    app.kubernetes.io/managed-by: Helm
data: 
  application.yml: | 
    zeebe:
      broker:
        experimental:
          maxAppendsPerFollower: 16
```

This overwrites the default application.yml which hopefully only contains default values.