### PR TITLE
fix: use native env vars to set worker and starter properties

### DIFF
--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -20,7 +20,7 @@ spec:
           image: "{{ .Values.global.image.repository }}/starter:{{ .Values.global.image.tag }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           env:
-            - name: JAVA_OPTIONS
+            - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl={{ .Release.Name }}-zeebe-gateway:26500

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -20,7 +20,7 @@ spec:
           image: "{{ .Values.global.image.repository }}/worker:{{ .Values.global.image.tag }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           env:
-            - name: JAVA_OPTIONS
+            - name: JDK_JAVA_OPTIONS
               value: >-
                 -Dconfig.override_with_env_vars=true
                 -Dapp.brokerUrl={{ .Release.Name }}-zeebe-gateway:26500


### PR DESCRIPTION
Once we start using worker and starter built by jib, `JAVA_OPTIONS` won't apply. Instead, we [can and should](https://stackoverflow.com/questions/52986487/what-is-the-difference-between-jdk-java-options-and-java-tool-options-when-using) use `JDK_JAVA_OPTIONS` 