### PR TITLE
fix: don't fail if no javaOpts are provided

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -145,6 +145,7 @@ camunda-platform:
           configMapKeyRef:
             name: zeebe-config
             key: java-opts
+            optional: true
 
 
     # Enable metrics collections
@@ -243,6 +244,7 @@ camunda-platform:
           configMapKeyRef:
             name: zeebe-config
             key: java-opts
+            optional: true
 
 
     # Enable metrics collections


### PR DESCRIPTION
The zeebe-config ConfigMap currently only has a `java-opts` field when profiling is enabled. Marking this as optional allows the  benchmark to start when profiling is not explicitly enabled.