### PR TITLE
feat: enhance release notes

### DIFF
--- a/charts/zeebe-benchmark/templates/NOTES.txt
+++ b/charts/zeebe-benchmark/templates/NOTES.txt
@@ -1,1 +1,22 @@
-# BENCHMARK FOR ZEEBE
+# Zeebe Benchmark
+
+Installed Zeebe cluster with:
+
+ * {{  index .Values "camunda-platform" "zeebe" "clusterSize" }} Brokers
+ * {{  index .Values "camunda-platform" "zeebe-gateway" "replicas" }} Gateways
+
+The benchmark is running with:
+
+ * Starter replicas={{ .Values.starter.replicas }}
+ * Worker replicas={{ .Values.worker.replicas }}
+ * Publisher replicas={{ .Values.publisher.replicas }}
+ * Timer replicas={{ .Values.timer.replicas }}
+
+{{ if .Values.zeebe.profiling.enabled }}
+Profiling enabled. Access pyroscope via port-forwarding:
+
+kubectl -n pyroscope port-forward svc/pyroscope 4040
+
+{{ end }}
+
+


### PR DESCRIPTION
Notes are printed when the chart is installed, which should help the user to understand what has been installed and how to use it.

closes #22 

**Example:**
```
$ helm install xzy charts/zeebe-benchmark --dry-run --set zeebe.profiling.enabled=true
...

NOTES:
# Zeebe Benchmark

Installed Zeebe cluster with:

 * 3 Brokers
 * 2 Gateways

The benchmark is running with:

 * Starter replicas=1
 * Worker replicas=3
 * Publisher replicas=0
 * Timer replicas=0


Profiling enabled. Access pyroscope via port-forwarding:

kubectl -n pyroscope port-forward svc/pyroscope 4040
```