### PR TITLE
feat: expose metrics port

### DIFF
--- a/charts/zeebe-benchmark/templates/publisher.yaml
+++ b/charts/zeebe-benchmark/templates/publisher.yaml
@@ -41,3 +41,6 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -41,3 +41,6 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/templates/timer.yaml
+++ b/charts/zeebe-benchmark/templates/timer.yaml
@@ -41,4 +41,7 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
 

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -42,3 +42,6 @@ spec:
             requests:
               cpu: 500m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
@@ -43,3 +43,6 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -43,3 +43,6 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/test/golden/timer.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/timer.golden.yaml
@@ -43,3 +43,6 @@ spec:
             requests:
               cpu: 250m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/charts/zeebe-benchmark/test/golden/worker.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/worker.golden.yaml
@@ -44,3 +44,6 @@ spec:
             requests:
               cpu: 500m
               memory: 256Mi
+          ports:
+            - containerPort: 9600
+              name: "http"


### PR DESCRIPTION
In order to export prometheus metrics we need to expose the right container port.

closes https://github.com/camunda/zeebe/issues/11988

------

Example for worker pod:

```
sum(rate(grpc_client_completed_total{namespace=~"$namespace"}[1m])) by (grpc_method, grpc_code)
```

![metrics](https://user-images.githubusercontent.com/2758593/224416531-6eb5450a-2a8e-47e6-b630-22b2677d6509.png)
