### PR TITLE
fix: remove trailing slash to rebalance leaders

### DIFF
--- a/charts/zeebe-benchmark/templates/leader-balancing-cron.yaml
+++ b/charts/zeebe-benchmark/templates/leader-balancing-cron.yaml
@@ -18,6 +18,6 @@ spec:
           containers:
             - image: "curlimages/curl:7.87.0"
               name: curl
-              args: ["-L", "-v", "-X", "POST", "http://{{ .Release.Name }}-zeebe-gateway:9600/actuator/rebalance/"]
+              args: ["-L", "-v", "-X", "POST", "http://{{ .Release.Name }}-zeebe-gateway:9600/actuator/rebalance"]
           restartPolicy: OnFailure
 {{- end }}

--- a/charts/zeebe-benchmark/test/golden/leader-balancing-cron.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/leader-balancing-cron.golden.yaml
@@ -22,5 +22,5 @@ spec:
           containers:
             - image: "curlimages/curl:7.87.0"
               name: curl
-              args: ["-L", "-v", "-X", "POST", "http://benchmark-test-zeebe-gateway:9600/actuator/rebalance/"]
+              args: ["-L", "-v", "-X", "POST", "http://benchmark-test-zeebe-gateway:9600/actuator/rebalance"]
           restartPolicy: OnFailure


### PR DESCRIPTION
By upgrading Spring Boot to version 3.x in Zeebe, the management endpoints will fail with a 404 when having a trailing slash, for example: `/actuator/rebalance/` (see https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#spring-mvc-and-webflux-url-matching-changes). This PR removes the trailing slashes when calling the rebalancing endpoint.

related to https://github.com/camunda/zeebe/pull/11103