### PR TITLE
refactor: migrate to standard Prometheus service monitor

### DIFF
--- a/charts/zeebe-benchmark/templates/clients-service.yaml
+++ b/charts/zeebe-benchmark/templates/clients-service.yaml
@@ -26,6 +26,7 @@ spec:
       app.kubernetes.io/component: zeebe-client
   endpoints:
   - honorLabels: true
-    interval: 10s
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: {{ index .Values "camunda-platform" "prometheusServiceMonitor" "scrapeInterval" }}
     path: /prometheus
     port: http

--- a/charts/zeebe-benchmark/templates/clients-service.yml
+++ b/charts/zeebe-benchmark/templates/clients-service.yml
@@ -4,11 +4,11 @@ kind: Service
 metadata:
   name: clients
   labels:
-    zeebe.io/component: client
+    app.kubernetes.io/component: zeebe-client
     {{- include "zeebe-benchmark.labels" . | nindent 4 }}
 spec:
   selector:
-    zeebe.io/component: client
+    app.kubernetes.io/component: zeebe-client
   ports:
   - name: http
     port: 9600
@@ -23,7 +23,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      zeebe.io/component: client
+      app.kubernetes.io/component: zeebe-client
   endpoints:
   - honorLabels: true
     interval: 10s

--- a/charts/zeebe-benchmark/templates/clients-service.yml
+++ b/charts/zeebe-benchmark/templates/clients-service.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    zeebe.io/component: client
+    {{- include "zeebe-benchmark.labels" . | nindent 4 }}
+spec:
+  selector:
+    zeebe.io/component: client
+  ports:
+  - name: http
+    port: 9600
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+    {{- include "zeebe-benchmark.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      zeebe.io/component: client
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    path: /prometheus
+    port: http

--- a/charts/zeebe-benchmark/templates/publisher.yaml
+++ b/charts/zeebe-benchmark/templates/publisher.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: publisher
+        zeebe.io/component: client
     spec:
       containers:
         - name: publisher

--- a/charts/zeebe-benchmark/templates/publisher.yaml
+++ b/charts/zeebe-benchmark/templates/publisher.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: publisher
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: publisher

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: starter
+        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: starter
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: starter

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: starter
-        metrics: gmp
+        zeebe.io/component: client
     spec:
       containers:
         - name: starter

--- a/charts/zeebe-benchmark/templates/timer.yaml
+++ b/charts/zeebe-benchmark/templates/timer.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: timer
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: timer

--- a/charts/zeebe-benchmark/templates/timer.yaml
+++ b/charts/zeebe-benchmark/templates/timer.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: timer
+        zeebe.io/component: client
     spec:
       containers:
         - name: timer
@@ -44,4 +45,3 @@ spec:
           ports:
             - containerPort: 9600
               name: "http"
-

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: worker
+        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: worker
-        metrics: gmp
+        zeebe.io/component: client
     spec:
       containers:
         - name: worker

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: worker
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: worker

--- a/charts/zeebe-benchmark/test/golden/clients-service.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/clients-service.golden.yaml
@@ -1,0 +1,40 @@
+---
+# Source: zeebe-benchmark/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+    app.kubernetes.io/name: zeebe-benchmark
+    app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: zeebe-benchmark/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+    app.kubernetes.io/name: zeebe-benchmark
+    app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /prometheus
+    port: http

--- a/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: publisher
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: publisher

--- a/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/publisher.golden.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: publisher
+        zeebe.io/component: client
     spec:
       containers:
         - name: publisher

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: starter
+        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: starter
-        metrics: gmp
+        zeebe.io/component: client
     spec:
       containers:
         - name: starter

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: starter
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: starter

--- a/charts/zeebe-benchmark/test/golden/timer.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/timer.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: timer
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: timer

--- a/charts/zeebe-benchmark/test/golden/timer.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/timer.golden.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: timer
+        zeebe.io/component: client
     spec:
       containers:
         - name: timer

--- a/charts/zeebe-benchmark/test/golden/worker.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/worker.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: worker
-        zeebe.io/component: client
+        app.kubernetes.io/component: zeebe-client
     spec:
       containers:
         - name: worker

--- a/charts/zeebe-benchmark/test/golden/worker.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/worker.golden.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: worker
+        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/test/golden/worker.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/worker.golden.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app: worker
-        metrics: gmp
+        zeebe.io/component: client
     spec:
       containers:
         - name: worker

--- a/charts/zeebe-benchmark/test/golden_test.go
+++ b/charts/zeebe-benchmark/test/golden_test.go
@@ -15,7 +15,7 @@ func TestGoldenCuratorDefaults(t *testing.T) {
 
 	chartPath, err := filepath.Abs("../")
 	require.NoError(t, err)
-	templateNames := []string{"leader-balancing-cron", "publisher", "starter", "timer", "worker", "zeebe-config"}
+	templateNames := []string{"clients-service", "leader-balancing-cron", "publisher", "starter", "timer", "worker", "zeebe-config"}
 
 	for _, name := range templateNames {
 		suite.Run(t, &golden.TemplateGoldenTest{

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -196,11 +196,6 @@ camunda-platform:
             key: java-opts
             optional: true
 
-
-    # Enable metrics collections
-    podLabels:
-      metrics: gmp
-
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
     resources:
       limits:
@@ -291,11 +286,6 @@ camunda-platform:
             key: java-opts
             optional: true
 
-
-    # Enable metrics collections
-    podLabels:
-      metrics: gmp
-
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
     resources:
       limits:
@@ -359,6 +349,8 @@ camunda-platform:
         cpu: 2
         memory: 6Gi
 
-  # Disable the service monitor as we use Google Managed Prometheus
+  # Change these settings to configure a different way to collect metrics
   prometheusServiceMonitor:
-    enabled: false
+    enabled: true
+    labels:
+      release: monitoring

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -196,6 +196,11 @@ camunda-platform:
             key: java-opts
             optional: true
 
+    # TODO: remove once migrated to self managed Prometheus
+    # Enable metrics collections
+    podLabels:
+      metrics: gmp
+
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
     resources:
       limits:
@@ -285,6 +290,11 @@ camunda-platform:
             name: zeebe-config
             key: java-opts
             optional: true
+
+    # TODO: remove once migrated to self managed Prometheus
+    # Enable metrics collections
+    podLabels:
+      metrics: gmp
 
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
     resources:

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -354,3 +354,4 @@ camunda-platform:
     enabled: true
     labels:
       release: monitoring
+    scrapeInterval: 30s


### PR DESCRIPTION
Migrates back from Google Managed Prometheus setup to the standard Prometheus service monitor. Our set up uses the label `release: monitoring` to grab service monitors.

Additionally adds a new template, `client-service.yml`, which adds a headless service and monitor to grab all client deployments. This works by adding a new label, `zeebe.io/component: client` to all of our clients.

If you know of a better label to use for the clients, let me know.