### PR TITLE
refactor: disable GMP integration via labels

### DIFF
--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: starter
-        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/templates/worker.yaml
+++ b/charts/zeebe-benchmark/templates/worker.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: worker
-        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/test/golden/starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter.golden.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         app: starter
-        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/test/golden/worker.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/worker.golden.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         app: worker
-        metrics: gmp
         app.kubernetes.io/component: zeebe-client
     spec:
       containers:

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -200,11 +200,6 @@ camunda-platform:
             key: java-opts
             optional: true
 
-    # TODO: remove once migrated to self managed Prometheus
-    # Enable metrics collections
-    podLabels:
-      metrics: gmp
-
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
     resources:
       limits:
@@ -294,11 +289,6 @@ camunda-platform:
             name: zeebe-config
             key: java-opts
             optional: true
-
-    # TODO: remove once migrated to self managed Prometheus
-    # Enable metrics collections
-    podLabels:
-      metrics: gmp
 
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
     resources:


### PR DESCRIPTION
This PR disables integration of benchmarks with Google Managed Prometheus, as we've now migrated to a self-managed stack.