### PR TITLE
fix: use renamed curator image

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -318,6 +318,16 @@ camunda-platform:
     # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted
     tasklistIndexTTL: 30
 
+  # Image configuration for the elasticsearch curator cronjob
+  # https://hub.docker.com/r/bitnami/elasticsearch-curator-archived/tags
+  image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
+    # Image.repository defines which image repository to use
+    repository: "bitnami/elasticsearch-curator-archived"
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: 5.8.4
+
   operate:
     enabled: false
 


### PR DESCRIPTION
Old curator image has been renamed by bitnami, to elasticsearch-curator-archived

See https://medium.com/@zelldon91/looks-like-bitnami-elasticsearch-curator-is-gone-db1fa2260a97