### PR TITLE
Add elastic metric exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ tools.zbctl-topology:
 .PHONY: helm.repos-add
 helm.repos-add:
 	helm repo add zeebe https://helm.camunda.io
+	helm repo add prometheus https://prometheus-community.github.io/helm-charts
 	helm repo update
 
 # helm.dependency-update: update and downloads the dependencies for the Helm chart

--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -12,6 +12,10 @@ dependencies:
     repository: "https://helm.camunda.io"
     version: 8.2.8
     condition: "camunda.enabled"
+  - name: prometheus-elasticsearch-exporter
+    repository: "https://prometheus-community.github.io/helm-charts"
+    version: 5.2.0
+    condition: "prometheus-elasticsearch-exporter.enabled"
 maintainers:
   - name: Zelldon
     email: christopher.zell@camunda.com

--- a/charts/zeebe-benchmark/test/golden/deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/deployment.golden.yaml
@@ -42,7 +42,7 @@ spec:
           command: ["elasticsearch_exporter",
                     "--log.format=logfmt",
                     "--log.level=info",
-                    "--es.uri=http://localhost:9200",
+                    "--es.uri=http://elasticsearch-master:9200",
                     "--es.all",
                     "--es.indices",
                     "--es.indices_settings",

--- a/charts/zeebe-benchmark/test/golden/deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/deployment.golden.yaml
@@ -1,0 +1,83 @@
+---
+# Source: zeebe-benchmark/charts/prometheus-elasticsearch-exporter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: benchmark-test-prometheus-elasticsearch-exporter
+  labels:
+    chart: prometheus-elasticsearch-exporter-5.2.0
+    app: prometheus-elasticsearch-exporter
+    release: "benchmark-test"
+    heritage: "Helm"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-elasticsearch-exporter
+      release: "benchmark-test"
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: prometheus-elasticsearch-exporter
+        release: "benchmark-test"
+    spec:
+      serviceAccountName: default
+      
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          env:
+          image: "quay.io/prometheuscommunity/elasticsearch-exporter:v1.5.0"
+          imagePullPolicy: IfNotPresent
+          command: ["elasticsearch_exporter",
+                    "--log.format=logfmt",
+                    "--log.level=info",
+                    "--es.uri=http://localhost:9200",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.indices_settings",
+                    "--es.indices_mappings",
+                    "--es.shards",
+                    "--es.snapshots",
+                    "--es.timeout=30s",
+                    "--web.listen-address=:9108",
+                    "--web.telemetry-path=/metrics"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - containerPort: 9108
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 20"]
+          volumeMounts:
+      volumes:

--- a/charts/zeebe-benchmark/test/golden/servicemonitor.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/servicemonitor.golden.yaml
@@ -1,0 +1,29 @@
+---
+# Source: zeebe-benchmark/charts/prometheus-elasticsearch-exporter/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: benchmark-test-prometheus-elasticsearch-exporter
+  labels:
+    chart: prometheus-elasticsearch-exporter-5.2.0
+    app: prometheus-elasticsearch-exporter
+    release: "benchmark-test"
+    heritage: "Helm"
+    release: monitoring
+spec:
+  endpoints:
+  - interval: 10s
+    scrapeTimeout: 10s
+    honorLabels: true
+    port: http
+    path: /metrics
+    scheme: http
+  jobLabel: benchmark-test
+  selector:
+    matchLabels:
+      app: prometheus-elasticsearch-exporter
+      release: "benchmark-test"
+  namespaceSelector:
+    matchNames:
+      - benchmark-65lu92
+  sampleLimit: 0

--- a/charts/zeebe-benchmark/test/golden/servicemonitor.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/servicemonitor.golden.yaml
@@ -25,5 +25,5 @@ spec:
       release: "benchmark-test"
   namespaceSelector:
     matchNames:
-      - benchmark-65lu92
+      - benchmark-test
   sampleLimit: 0

--- a/charts/zeebe-benchmark/test/golden_camunda_platform_test.go
+++ b/charts/zeebe-benchmark/test/golden_camunda_platform_test.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"benchmark-helm/charts/zeebe-benchmark/test/golden"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenCamundaPlatformDefaults(t *testing.T) {
+	// Test which allows to verify also parent chart templates
+	// This makes sure that properties are correctly set
+	// OR configurations have been changed
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+	templateNames := []string{"curator-cronjob", "curator-configmap", "service-monitor"}
+
+	for _, name := range templateNames {
+		suite.Run(t, &golden.TemplateGoldenTest{
+			ChartPath:      chartPath,
+			Release:        "benchmark-test",
+			Namespace:      "benchmark-" + strings.ToLower(random.UniqueId()),
+			GoldenFileName: name,
+			Templates:      []string{"charts/camunda-platform/templates/" + name + ".yaml"},
+			SetValues:      map[string]string{"retentionPolicy.enabled": "true"},
+		})
+	}
+}

--- a/charts/zeebe-benchmark/test/golden_elastic_exporter_test.go
+++ b/charts/zeebe-benchmark/test/golden_elastic_exporter_test.go
@@ -3,10 +3,8 @@ package test
 import (
 	"benchmark-helm/charts/zeebe-benchmark/test/golden"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,10 +22,9 @@ func TestGoldenElasticExporterDefaults(t *testing.T) {
 		suite.Run(t, &golden.TemplateGoldenTest{
 			ChartPath:      chartPath,
 			Release:        "benchmark-test",
-			Namespace:      "benchmark-" + strings.ToLower(random.UniqueId()),
+			Namespace:      "benchmark-test",
 			GoldenFileName: name,
 			Templates:      []string{"charts/prometheus-elasticsearch-exporter/templates/" + name + ".yaml"},
-			SetValues:      map[string]string{"retentionPolicy.enabled": "true"},
 		})
 	}
 }

--- a/charts/zeebe-benchmark/test/golden_elastic_exporter_test.go
+++ b/charts/zeebe-benchmark/test/golden_elastic_exporter_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestGoldenDefaults(t *testing.T) {
+func TestGoldenElasticExporterDefaults(t *testing.T) {
 	// Test which allows to verify also parent chart templates
 	// This makes sure that properties are correctly set
 	// OR configurations have been changed
 
 	chartPath, err := filepath.Abs("../")
 	require.NoError(t, err)
-	templateNames := []string{"curator-cronjob", "curator-configmap", "service-monitor"}
+	templateNames := []string{"servicemonitor", "deployment"}
 
 	for _, name := range templateNames {
 		suite.Run(t, &golden.TemplateGoldenTest{
@@ -26,7 +26,7 @@ func TestGoldenDefaults(t *testing.T) {
 			Release:        "benchmark-test",
 			Namespace:      "benchmark-" + strings.ToLower(random.UniqueId()),
 			GoldenFileName: name,
-			Templates:      []string{"charts/camunda-platform/templates/" + name + ".yaml"},
+			Templates:      []string{"charts/prometheus-elasticsearch-exporter/templates/" + name + ".yaml"},
 			SetValues:      map[string]string{"retentionPolicy.enabled": "true"},
 		})
 	}

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -386,3 +386,13 @@ camunda-platform:
     labels:
       release: monitoring
     scrapeInterval: 30s
+
+prometheus-elasticsearch-exporter:
+  serviceMonitor:
+    ## If true, a ServiceMonitor CRD is created for a prometheus operator
+    ## https://github.com/coreos/prometheus-operator
+    ##
+    enabled: true
+    # Labels used by the service monitor, specific to our prometheus installation
+    labels:
+      release: monitoring

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -388,6 +388,13 @@ camunda-platform:
     scrapeInterval: 30s
 
 prometheus-elasticsearch-exporter:
+  es:
+    ## Address (host and port) of the Elasticsearch node we should connect to.
+    ## This could be a local node (localhost:9200, for instance), or the address
+    ## of a remote Elasticsearch server. When basic auth is needed,
+    ## specify as: <proto>://<user>:<password>@<host>:<port>. e.g., http://admin:pass@localhost:9200.
+    ##
+    uri: http://elasticsearch-master:9200
   serviceMonitor:
     ## If true, a ServiceMonitor CRD is created for a prometheus operator
     ## https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
In order to support Operate in our benchmarks we want to also add the elasticsearch metric exporter to our benchmarks.

Related project https://app.slack.com/client/T0PM0P1SA/C05GGP8C214

Since it is also interesting to see how elasticsearch behaves without Operate I want to enable it by default.

This PR adds https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-elasticsearch-exporter as dependency and sets the right properties, like servicemonitor and connection URL. 

Furthermore, we add some golden tests to verify that the resources are added and deployed with right configs.

--------

Example deployment https://grafana.dev.zeebe.io/d/elasticsearch/elasticsearch?orgId=1&var-server=Prometheus&var-cluster=All&var-namespace=ck-helm-test&var-index=All&from=now-15m&to=now

![deploy](https://github.com/zeebe-io/benchmark-helm/assets/2758593/4437fccb-04b6-4575-830e-2515393b4e50)
