### PR TITLE
fix: set index size to 1

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-curator-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-curator-configmap.golden.yaml
@@ -104,7 +104,7 @@ data:
             kind: prefix
             value: zeebe-
           - filtertype: space
-            disk_space: 30
+            disk_space: 1
             source: name
             timestring: '%Y-%m-%d'
   config.yml: |-

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -318,7 +318,7 @@ camunda-platform:
     # RetentionPolicy.zeebeIndexMaxSize can be set to configure the maximum allowed zeebe index size in gigabytes.
     # After reaching that size, curator will delete that corresponding index on the next run.
     # To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes.
-    zeebeIndexMaxSize: 30
+    zeebeIndexMaxSize: 1
     # RetentionPolicy.operateIndexTTL defines after how many days an operate index can be deleted
     operateIndexTTL: 1
     # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted


### PR DESCRIPTION
Sets the maximum index size back to one, such that we delete indices early. We need to reconfigure this when we enable operate, but this can be done separately for that specific benchmark.