### PR TITLE
fix: match memory request and limit for brokers

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -215,7 +215,7 @@ camunda-platform:
         memory: 4Gi
       requests:
         cpu: 1350m
-        memory: 2Gi
+        memory: 4Gi
 
     nodeSelector:
       cloud.google.com/gke-nodepool: n2-standard-2


### PR DESCRIPTION
Requesting just 2GiB of memory while setting the limit to 4GiB leads to brokers using more than 2 GiB and gettign OOMKilled. For example, a broker on an old version with dispatcher will use 1.5GiB for RocksDb, ~600MiB for the dispatcher and up to 1 GiB for heap. So the requested memory is exhausted anyway and the memory limit isn't too far away either.
If we factor in non-heap memory usage by the JVM and daemon pods that often run without resource limits, it is likely that kubernetes occasionally kills brokers because nodes are under memory pressure.
Setting the requested memory to be 4GiB should prevent that. If we still observe OOMKilled events we can then assume that the broker actually did use more than 4GiB and investigate this properly.