### PR TITLE
More fine granular retention policy

### DIFF
--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -9,6 +9,7 @@
 - [Configuration](#configuration)
     - [Global](#global)
     - [Camunda Platform](#camunda-platform)
+    - [Retention Policy](#retention-policy)
     - [Worker](#worker)
     - [Starter](#publisher)
     - [Publisher](#starter)
@@ -139,6 +140,19 @@ camunda-platform:
 ```
 
 Per default Zeebe and Zeebe-Gateway are enabled and all other components are disabled.
+
+### Retention Policy
+
+Allows to configure the elasticsearch index retention policies, which are much more fine granular in contrast to the ones provided by the parent helm chart (camunda-platform). 
+
+| Section | Parameter | Description | Default |
+|-|-|-|-|
+| `retentionPolicy` | | Configuration to configure the elasticsearch index retention policies | |
+| | `enabled` | If true, elasticsearch curator cronjob and configuration will be deployed. | `false` |
+| | `schedule` |Defines how often/when the curator should run. | `"0 * * * *"` |
+| | `policies` |Defines a list of policies, which allows to specify policies for specific indexes or globally (based on the pattern specified). | `"0 * * * *"` |
+| | `image` |Configuration for the elasticsearch curator cronjob. ||
+
 
 ### Worker
 

--- a/charts/zeebe-benchmark/templates/curator-configmap.yaml
+++ b/charts/zeebe-benchmark/templates/curator-configmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: camunda-platform-curator-config
+  name: zeebe-benchmark-curator-config
   labels:
-    {{- include "camundaPlatform.labels" . | nindent 4 }}
+    {{- include "zeebe-benchmark.labels" . | nindent 4 }}
 data:
   action_file.yml: |-
     ---

--- a/charts/zeebe-benchmark/templates/curator-configmap.yaml
+++ b/charts/zeebe-benchmark/templates/curator-configmap.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.retentionPolicy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: camunda-platform-curator-config
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+data:
+  action_file.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    actions:
+      {{- $counter := 1 | int }}
+      {{- range $policy := .Values.retentionPolicy.policies }}
+      {{ $counter }}:
+      {{- if $policy.timeToLive }}
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: {{ $policy.name }}
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: {{ $policy.timeToLive }}
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      {{- else }}
+        action: delete_indices
+        description: "Clean up ES by deleting too big indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: space
+            disk_space: {{ $policy.maxSize }}
+            source: name
+            timestring: '%Y-%m-%d'
+      {{- end }}
+      {{- $counter = add1 $counter }}
+      {{- end }}
+  config.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    client:
+      hosts:
+        - elasticsearch-master-headless
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']
+{{- end }}

--- a/charts/zeebe-benchmark/templates/curator-cronjob.yaml
+++ b/charts/zeebe-benchmark/templates/curator-cronjob.yaml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: camunda-platform-curator
+  name: zeebe-benchmark-curator
   labels:
-    {{- include "camundaPlatform.labels" . | nindent 4 }}
+    {{- include "zeebe-benchmark.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.retentionPolicy.schedule | quote }}
   successfulJobsHistoryLimit: 1

--- a/charts/zeebe-benchmark/templates/curator-cronjob.yaml
+++ b/charts/zeebe-benchmark/templates/curator-cronjob.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.retentionPolicy.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: camunda-platform-curator
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.retentionPolicy.schedule | quote }}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: "{{ .Values.retentionPolicy.image.repository }}:{{ .Values.retentionPolicy.image.tag }}"
+              name: curator
+              args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/config
+          volumes:
+            - name: config
+              configMap:
+                name: camunda-platform-curator-config
+                defaultMode: 0744
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/zeebe-benchmark/test/golden/curator-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/curator-configmap.golden.yaml
@@ -3,14 +3,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: camunda-platform-curator-config
+  name: zeebe-benchmark-curator-config
   labels:
-    
     app.kubernetes.io/name: zeebe-benchmark
     app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/version: "8.2.5"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
 data:
   action_file.yml: |-
     ---

--- a/charts/zeebe-benchmark/test/golden/curator-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/curator-configmap.golden.yaml
@@ -1,0 +1,121 @@
+---
+# Source: zeebe-benchmark/templates/curator-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: camunda-platform-curator-config
+  labels:
+    
+    app.kubernetes.io/name: zeebe-benchmark
+    app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "SNAPSHOT"
+data:
+  action_file.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    actions:
+      1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: 2
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      2:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: operate-
+          - filtertype: age
+            source: name
+            direction: older
+            timestring: '%Y-%m-%d'
+            unit: days
+            unit_count: 1
+            field:
+            stats_result:
+            epoch:
+            exclude: False
+      3:
+        action: delete_indices
+        description: "Clean up ES by deleting too big indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: space
+            disk_space: 1
+            source: name
+            timestring: '%Y-%m-%d'
+      4:
+        action: delete_indices
+        description: "Clean up ES by deleting too big indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+          - filtertype: pattern
+            kind: prefix
+            value: zeebe-
+          - filtertype: space
+            disk_space: 1
+            source: name
+            timestring: '%Y-%m-%d'
+  config.yml: |-
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    client:
+      hosts:
+        - elasticsearch-master-headless
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']

--- a/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
@@ -1,0 +1,36 @@
+---
+# Source: zeebe-benchmark/templates/curator-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: camunda-platform-curator
+  labels:
+    
+    app.kubernetes.io/name: zeebe-benchmark
+    app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "SNAPSHOT"
+spec:
+  schedule: "*/15 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - image: "bitnami/elasticsearch-curator-archived:5.8.4"
+              name: curator
+              args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/config
+          volumes:
+            - name: config
+              configMap:
+                name: camunda-platform-curator-config
+                defaultMode: 0744
+          restartPolicy: OnFailure

--- a/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
@@ -3,16 +3,14 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: camunda-platform-curator
+  name: zeebe-benchmark-curator
   labels:
-    
     app.kubernetes.io/name: zeebe-benchmark
     app.kubernetes.io/instance: benchmark-test
+    app.kubernetes.io/version: "8.2.5"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "0 * * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/charts/zeebe-benchmark/test/golden_test.go
+++ b/charts/zeebe-benchmark/test/golden_test.go
@@ -15,7 +15,7 @@ func TestGoldenCuratorDefaults(t *testing.T) {
 
 	chartPath, err := filepath.Abs("../")
 	require.NoError(t, err)
-	templateNames := []string{"clients-service", "leader-balancing-cron", "publisher", "starter", "timer", "worker", "zeebe-config"}
+	templateNames := []string{"clients-service", "leader-balancing-cron", "publisher", "starter", "timer", "worker", "zeebe-config", "curator-configmap", "curator-cronjob"}
 
 	for _, name := range templateNames {
 		suite.Run(t, &golden.TemplateGoldenTest{

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -97,10 +97,9 @@ zeebe:
 # RetentionPolicy configuration to configure the elasticsearch index retention policies
 retentionPolicy:
   # RetentionPolicy.enabled if true, elasticsearch curator cronjob and configuration will be deployed.
-  enabled: false
+  enabled: false # only enabled if really needed
   # RetentionPolicy.schedule defines how often/when the curator should run
-  schedule: "*/15 * * * *"
-
+  schedule: "0 * * * *" # every full hour at minute 0 https://crontab.guru/#0_*_*_*_*
   # Policies defines a list of policies, which allows to specify policies for specific indexes or globally (based
   # on the pattern specified). The policy is applied via the name, which is used as pattern to match indices.
   # Each policy can define the maxSize and timeToLive.

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -94,6 +94,44 @@ zeebe:
     # Zeebe.profiling.enabled if true, enables the pyroscope profiling
     enabled: false
 
+# RetentionPolicy configuration to configure the elasticsearch index retention policies
+retentionPolicy:
+  # RetentionPolicy.enabled if true, elasticsearch curator cronjob and configuration will be deployed.
+  enabled: false
+  # RetentionPolicy.schedule defines how often/when the curator should run
+  schedule: "*/15 * * * *"
+
+  # Policies defines a list of policies, which allows to specify policies for specific indexes or globally (based
+  # on the pattern specified). The policy is applied via the name, which is used as pattern to match indices.
+  # Each policy can define the maxSize and timeToLive.
+  #
+  # MaxSize can be set to configure the maximum allowed index size in gigabytes. After reaching that size, curator will
+  # delete that corresponding index on the next run. To benefit from that configuration the schedule needs to be
+  # configured small enough, like every 15 minutes.
+  #
+  # TimeToLive defines after how many days an index can be deleted
+  policies:
+    - name: zeebe-
+      maxSize:
+      timeToLive: 2
+    - name: operate-
+      timeToLive: 1
+    # the following are not consumed by operate so we want to get rid of them rather quickly
+    - name: zeebe-record_message
+      maxSize: 1
+    - name: zeebe-record_process-instance-creation
+      maxSize: 1
+  # Image configuration for the elasticsearch curator cronjob
+  # https://hub.docker.com/r/bitnami/elasticsearch-curator-archived/tags
+  image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
+    # Image.repository defines which image repository to use
+    repository: bitnami/elasticsearch-curator-archived
+    # Image.tag defines the tag / version which should be used in the chart
+    tag: 5.8.4
+
+
 camunda-platform:
   enabled: true
   global:


### PR DESCRIPTION
Adds a new retention policy to the helm chart which allows to configure indice deletion on a more fine granular level.

It is per default disabled, since we will use in our normal benchmarks the old approach. But if we need it we can enable it, in the operate benchmarks for example and disable the old (which comes from the parent chart)

With the new retention policy we can define policy for each specific index name or for a certain pattern, etc.