### PR TITLE
fix: refer to custom curator config map

### DIFF
--- a/charts/zeebe-benchmark/templates/curator-cronjob.yaml
+++ b/charts/zeebe-benchmark/templates/curator-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
           volumes:
             - name: config
               configMap:
-                name: camunda-platform-curator-config
+                name: zeebe-benchmark-curator-config
                 defaultMode: 0744
           restartPolicy: OnFailure
 {{- end }}

--- a/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/curator-cronjob.golden.yaml
@@ -29,6 +29,6 @@ spec:
           volumes:
             - name: config
               configMap:
-                name: camunda-platform-curator-config
+                name: zeebe-benchmark-curator-config
                 defaultMode: 0744
           restartPolicy: OnFailure


### PR DESCRIPTION
We use  a custom config map and not the generic camunda-platform one. Without this fix, the curator fails to run because it can't find the configmap.

Closes #100 