### PR TITLE
improve(operate): reduce log level to INFO

### DIFF
--- a/charts/zeebe-benchmark/test/golden/operate-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/operate-configmap.golden.yaml
@@ -41,6 +41,6 @@ data:
     logging:
       level:
         ROOT: INFO
-        io.camunda.operate: DEBUG
+        io.camunda.operate: INFO
     #Spring Boot Actuator endpoints to be exposed
     management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backups

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -393,6 +393,10 @@ camunda-platform:
           fieldRef:
             fieldPath: metadata.namespace  
 
+    logging:
+      level:
+        io.camunda.operate: INFO
+
   tasklist:
     enabled: false
 


### PR DESCRIPTION
In benchmarks with Operate, the majority of logs were coming from Operate, this should greatly reduce the costs for it.
![image](https://github.com/zeebe-io/benchmark-helm/assets/209518/f05a3fa9-71ad-4628-81f9-692f586cc19a)

Will become obsolete once https://github.com/camunda/camunda-platform-helm/pull/1092 is merged but we may still keep a default config in the values of the benchmark chart.