### PR TITLE
improve(gateway): increased memory to cover for push spikes

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -339,10 +339,10 @@ camunda-platform:
     resources:
       limits:
         cpu: 450m
-        memory: 400Mi
+        memory: 1Gi
       requests:
         cpu: 450m
-        memory: 400Mi
+        memory: 1Gi
 
   # RetentionPolicy configuration to configure the elasticsearch index retention policies
   retentionPolicy:


### PR DESCRIPTION
closes [#15000](https://github.com/camunda/zeebe/issues/15000)