### PR TITLE
Reduce elastic master name

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -396,6 +396,8 @@ camunda-platform:
     imageTag: 8.9.2
 
     master:
+      fullnameOverride: elastic
+      nameOverride: elastic
       # Number of master-elegible replicas to deploy
       replicaCount: 3
       pdb:


### PR DESCRIPTION
## Description

We recently updated to the Camunda Platform 9.x chart, which uses now a different ES chart ([bitnami](https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch))

### Problem

Our recent benchmark setup for this week (CW 04) failed because ES was not installed properly. 

![failed-es](https://github.com/zeebe-io/benchmark-helm/assets/2758593/79919864-8952-499f-8dc4-603b9bccc5ae)

The statefulset failed with:

```
Warning  FailedCreate  55s (x138 over 33h)  statefulset-controller  create Pod medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch-master-0 in StatefulSet medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch-master failed error: Pod "medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch-master-0" is invalid: metadata.labels: Invalid value: "medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch-master-586689ff7": must be no more than 63 characters
```

The problem is that the stateful set controller is adding to each pod a `controller-revision-hash` based on the name of the statefulset and a hash => `"medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch-master-586689ff7"` this was too long unfortunately. See related bug issue in K8 https://github.com/kubernetes/kubernetes/issues/64023

Previously this was better truncated or the name of the statefulset was shorter (not 100% sure). Anyhow we have to reduce the ES statefulset name. 

I used the [override properties](https://github.com/bitnami/charts/blob/main/bitnami/elasticsearch/values.yaml#L485-L490) to set it to: `elastic` which are used in the statefulset to set the corresponding names.

### Example


With this change:

```
helm install medic-y-2024-cw-04-0778ec7-benchmark zeebe-benchmark/zeebe-benchmark --namespace medic-y-2024-cw-04-0778ec7-benchmark --set global.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-0778ec7 --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe --set camunda-platform.zeebe.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-0778ec7 --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe --set camunda-platform.zeebe-gateway.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-0778ec7 --set camunda-platform.elasticsearch.master.fullnameOverride="elastic" --set camunda-platform.elasticsearch.master.nameOverride="elastic" --atomic
```

We were able to deploy the benchmarks without issues.


```
$ kgpo
NAME                                                              READY   STATUS      RESTARTS   AGE
elastic-0                                                         1/1     Running     0          19m
elastic-1                                                         1/1     Running     0          19m
elastic-2                                                         1/1     Running     0          19m
leader-balancer-28433745-kcd4v                                    0/1     Completed   0          6m49s
medic-y-2024-cw-04-0778ec7-benchmark-prometheus-elasticseap29fs   1/1     Running     0          19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-0                      1/1     Running     0          19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-1                      1/1     Running     0          19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-2                      1/1     Running     0          19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-gateway-7f965fbj86cf   1/1     Running     0          19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-gateway-7f965fbmjzjq   1/1     Running     0          19m
starter-687c68bbf6-bpk27                                          1/1     Running     0          19m
worker-6bc6b4c4fc-lkp52                                           1/1     Running     0          19m
worker-6bc6b4c4fc-lnmvn                                           1/1     Running     0          19m
worker-6bc6b4c4fc-ptpdv                                           1/1     Running     0          19m
```

```
$ k get pvc
NAME                                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data-elastic-0                                      Bound    pvc-b84c734a-4983-4b7f-bb45-6d1e0fa7221c   16Gi       RWO            ssd            19m
data-elastic-1                                      Bound    pvc-74e6e06b-ae05-4d2f-ba62-e220922f070e   16Gi       RWO            ssd            19m
data-elastic-2                                      Bound    pvc-db32ccfa-7e27-49bd-b0f0-c27165c7c677   16Gi       RWO            ssd            19m
data-medic-y-2024-cw-04-0778ec7-benchmark-zeebe-0   Bound    pvc-9de37a4a-dfd8-427a-ba22-c96b1fb7a6fc   32Gi       RWO            ssd            19m
data-medic-y-2024-cw-04-0778ec7-benchmark-zeebe-1   Bound    pvc-1345f7de-062d-45e4-a2ca-3ef4d2af382f   32Gi       RWO            ssd            19m
data-medic-y-2024-cw-04-0778ec7-benchmark-zeebe-2   Bound    pvc-0693c522-d16c-4c14-9f88-6b9da8a0be0f   32Gi       RWO            ssd            19m
```

Pods and pvcs look a bit different, but svc is still under the same name available and cluster is able to export.


```
$ k get svc
NAME                                                              TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)                        AGE
clients                                                           ClusterIP   10.4.13.183   <none>        9600/TCP                       19m
elastic-hl                                                        ClusterIP   None          <none>        9200/TCP,9300/TCP              19m
medic-y-2024-cw-04-0778ec7-benchmark-elasticsearch                ClusterIP   10.4.12.112   <none>        9200/TCP,9300/TCP              19m
medic-y-2024-cw-04-0778ec7-benchmark-prometheus-elasticsearch-e   ClusterIP   10.4.12.159   <none>        9108/TCP                       19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe                        ClusterIP   None          <none>        9600/TCP,26502/TCP,26501/TCP   19m
medic-y-2024-cw-04-0778ec7-benchmark-zeebe-gateway                ClusterIP   10.4.1.51     <none>        
9600/TCP,26500/TCP             19m
```


![general](https://github.com/zeebe-io/benchmark-helm/assets/2758593/98a51925-fcf2-40bb-8d29-f36003ee8fba)

![general-es](https://github.com/zeebe-io/benchmark-helm/assets/2758593/aeed1d37-c4a4-4a65-b918-53968bfc946d)