### PR TITLE
Increase Operate retention period

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -356,7 +356,7 @@ camunda-platform:
       ## @param operate.retention.enabled if true, the ILM Policy is created and applied to the index templates.
       enabled: true
       ## @param operate.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
-      minimumAge: 30m # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick
+      minimumAge: 1d # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick
 
     env:
       - name: OPERATE_LOG_APPENDER


### PR DESCRIPTION
Since dated indices are creates per day, if we define retention period for 30 minutes, indices are deleted and recreated again and again, provoking archiver failures and retries. This does not seem optimal.
Increased retention period till 1day.