### PR TITLE
Rename camunda/zeebe repo

### DIFF
--- a/charts/zeebe-benchmark/Chart-with-artifacthub-changes.yaml.tmp
+++ b/charts/zeebe-benchmark/Chart-with-artifacthub-changes.yaml.tmp
@@ -6,7 +6,7 @@ version: 0.2.1
 appVersion: "8.2.5"
 sources:
   - https://github.com/zeebe-io/benchmark-helm
-  - https://github.com/camunda/zeebe
+  - https://github.com/camunda/camunda
 dependencies:
   - name: camunda-platform
     repository: "https://helm.camunda.io"
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/links: |
     - name: Zeebe Repo
-      url: https://github.com/camunda/zeebe
+      url: https://github.com/camunda/camunda
     - name: Zeebe Docs
       url: https://docs.camunda.io/docs/components/zeebe/zeebe-overview/
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.1
 appVersion: "8.2.5"
 sources:
   - https://github.com/zeebe-io/benchmark-helm
-  - https://github.com/camunda/zeebe
+  - https://github.com/camunda/camunda
 dependencies:
   - name: camunda-platform
     repository: "https://helm.camunda.io"
@@ -22,7 +22,7 @@ maintainers:
 annotations:
   artifacthub.io/links: |
     - name: Zeebe Repo
-      url: https://github.com/camunda/zeebe
+      url: https://github.com/camunda/camunda
     - name: Zeebe Docs
       url: https://docs.camunda.io/docs/components/zeebe/zeebe-overview/
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -156,7 +156,7 @@ Allows to configure the elasticsearch index retention policies, which are much m
 
 ### Worker
 
-Allows to configure the workers which can be deployed along the Zeebe Cluster. The worker code can be found [here](https://github.com/camunda/zeebe/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java).
+Allows to configure the workers which can be deployed along the Zeebe Cluster. The worker code can be found [here](https://github.com/camunda/camunda/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java).
 
 | Section | Parameter | Description | Default |
 |-|-|-|-|
@@ -167,7 +167,7 @@ Allows to configure the workers which can be deployed along the Zeebe Cluster. T
 
 ### Starter
 
-Allows to configure the starter which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/zeebe/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
+Allows to configure the starter which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/camunda/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
 
 | Section | Parameter | Description | Default |
 |-|-|-|-|
@@ -178,7 +178,7 @@ Allows to configure the starter which can be deployed along the Zeebe Cluster. T
 
 ### Publisher
 
-Allows to configure the publisher which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/zeebe/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
+Allows to configure the publisher which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/camunda/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
 
 | Section | Parameter | Description | Default |
 |-|-|-|-|
@@ -188,7 +188,7 @@ Allows to configure the publisher which can be deployed along the Zeebe Cluster.
 
 ### Timer
 
-Allows to configure the timer which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/zeebe/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
+Allows to configure the timer which can be deployed along the Zeebe Cluster. The start code can be found [here](https://github.com/camunda/camunda/blob/main/benchmarks/project/src/main/java/io/camunda/zeebe/Starter.java).
 
 | Section | Parameter | Description | Default |
 |-|-|-|-|


### PR DESCRIPTION
## Description

The repository camunda/zeebe will be renamed to camunda/camunda, this PR adjusts all references to this repository.

> **WHY**
> The name of this repository will be changed to align better with its new role as a monorepo containing multiple products of the stack.
> https://github.com/camunda/zeebe/issues/18206


### Details 

I renamed all occurrences of github.com/camunda/zeebe. I didn't do this for camunda/zeebe as this will change occurrences for docker images (which we do not plan to change yet).

For posterity, the following script has been used.

```sh
#!/bin/bash

set -euox pipefail
path=$1

# Replace occurence in markdown files
find "$path" -type f -exec sed -i -E 's|github.com/camunda/zeebe([/#])?|github.com/camunda/camunda\1|g' {} \;


count=$(git -C "$path" status | grep modified -c)
echo "$count files have been updated."

if ag 'github.com/camunda/zeebe/' "$path" > /dev/null
then
  echo "There are still some occurences left, that need to be renamed! "
else
  echo "All occurences of 'github.com/camunda/zeebe/' have been renamed!"
fi
```

## Related issues

related https://github.com/camunda/zeebe/issues/18206
