### PR TITLE
Migrate to alpha charts

### DIFF
--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -9,8 +9,8 @@ sources:
   - https://github.com/camunda/camunda
 dependencies:
   - name: camunda-platform
-    repository: "https://helm.camunda.io"
-    version: 10.2.1
+    repository: "oci://ghcr.io/camunda/helm"
+    version: "0.0.0-8.6.0-alpha4"
     condition: "camunda.enabled"
   - name: prometheus-elasticsearch-exporter
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/zeebe-benchmark/test/golden/c8-operate-service-monitor.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-operate-service-monitor.golden.yaml
@@ -19,5 +19,5 @@ spec:
   endpoints:
     - honorLabels: true
       path: /actuator/prometheus
-      port: http
+      port: management
       interval: 30s

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-configmap.golden.yaml
@@ -51,6 +51,15 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://benchmark-test-elasticsearch:9200"
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-configmap.golden.yaml
@@ -16,6 +16,14 @@ data:
   gateway-log4j2.xml: |
   application.yaml: |
 
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://benchmark-test-elasticsearch:9200"
+
     server:
       address: "0.0.0.0"
       port: "8080"
@@ -27,3 +35,6 @@ data:
         cluster:
           clusterName: benchmark-test-zeebe
           port: "26502"
+        network:
+          host: 0.0.0.0
+          port: "26500"

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: RollingUpdate
   replicas: 2
   selector:
     matchLabels:
@@ -35,7 +37,7 @@ spec:
         app.kubernetes.io/component: zeebe-gateway
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 097f011c56a9c3d0128c753acfcb770ea4cde9b9463b24a69dace77a61c49eb5
+        checksum/config: abff6fd01d361fd30b47a05f3d11a59b0faffc911dbd3da2ef3e5d02854d8810
     spec:
       imagePullSecrets:
         []
@@ -69,6 +71,11 @@ spec:
             - containerPort: 8080
               name: rest
           env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
             - name: ZEEBE_STANDALONE_GATEWAY
               value: "true"
             - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
@@ -81,10 +88,6 @@ spec:
               value: "-XX:+ExitOnOutOfMemoryError"
             - name: ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS
               value: benchmark-test-zeebe:26502
-            - name: ZEEBE_GATEWAY_NETWORK_HOST
-              value: 0.0.0.0
-            - name: ZEEBE_GATEWAY_NETWORK_PORT
-              value: "26500"
             - name: ZEEBE_GATEWAY_CLUSTER_HOST
               valueFrom:
                 fieldRef:

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: zeebe-broker
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 6776a5924f028d3417742af59ee3d8754fe420cf0dc83e4370d1700fb08ea638
+        checksum/config: 99e2f60769668f254fe17c8e36f9a93ad520532142d153c99bdbf6aa1ff0cddf
     spec:
       imagePullSecrets:
         []
@@ -74,6 +74,11 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
             - name: LC_ALL
               value: C.UTF-8
             - name: K8S_NAME
@@ -87,12 +92,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
-                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
+                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME):26502,
             - name: ZEEBE_LOG_LEVEL
               value: "info"
             - name: ZEEBE_BROKER_GATEWAY_ENABLE

--- a/charts/zeebe-benchmark/test/golden/operate-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/operate-configmap.golden.yaml
@@ -11,13 +11,21 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.5.4"
+    app.kubernetes.io/version: "SNAPSHOT"
 data:
-  application.yml: |
+  application.yaml: |
     spring:
       profiles:
         active: "auth"
-    
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://benchmark-test-elasticsearch:9200"
+
     # Operate configuration file
     camunda.operate:
     
@@ -45,8 +53,8 @@ data:
         url: "http://benchmark-test-elasticsearch:9200"
       # Zeebe instance
       zeebe:
-        # Broker contact point
-        brokerContactPoint: "benchmark-test-zeebe-gateway:26500"
+        # Gateway address
+        gatewayAddress: "benchmark-test-zeebe-gateway:26500"
       archiver:
         ilmEnabled: true
         ilmMinAgeForDeleteArchivedIndices: 30m

--- a/charts/zeebe-benchmark/test/golden/operate-deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/operate-deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.5.4"
+    app.kubernetes.io/version: "SNAPSHOT"
   annotations:
     {}
 spec:
@@ -35,14 +35,40 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: operate
-        app.kubernetes.io/version: "8.5.4"
+        app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 1cfe01b812571d8f3a237c6dc3832c47d12b5e0d7f33cca794baee7f279d8137
+        checksum/config: f0836a0e6c8d3e8f2132c68c20ed4ca2e95d97a467dc72c6e6121bdcc3cfdd11
     spec:
       imagePullSecrets:
         []
       initContainers:
-        []
+        - name: migration
+          image: camunda/operate:SNAPSHOT
+          command: ['/bin/sh', '/usr/local/operate/bin/migrate']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: camunda
+              mountPath: /camunda
       containers:
         - name: operate
           image: camunda/operate:SNAPSHOT
@@ -56,8 +82,35 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: /tmp/zeebe_auth_cache
+            # the host name of Operate that is used when connecting with the Zeebe cluster
+            # via atomix-cluster (SWIM)
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            # the unique member id (in this case the pod name) that is used as identifier inside the SWIM cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            # the name of the atomix cluster (SWIM) to connect to (must be the same as for the Zeebe cluster)
+            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
+              value: benchmark-test-zeebe
+            # the port the service expects requests/messages from the atomix cluster (must be exposed internally)
+            - name: ZEEBE_GATEWAY_CLUSTER_PORT
+              value: "26502"
+            # the initial contact point to join the SWIM (atomix) cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS
+              value: benchmark-test-zeebe:26502
             - name: OPERATE_LOG_APPENDER
               value: Stackdriver
             - name: OPERATE_LOG_STACKDRIVER_SERVICENAME
@@ -78,11 +131,16 @@ spec:
             - containerPort: 8080
               name: http
               protocol: TCP
+            - containerPort: 9600
+              name: management
+            - containerPort: 26502
+              name: internal
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               scheme: HTTP
-              port: http
+              port: management
             initialDelaySeconds: 30
             periodSeconds: 30
             successThreshold: 1
@@ -90,8 +148,8 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
             - name: config
-              mountPath: /usr/local/operate/config/application.yml
-              subPath: application.yml
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
             - name: tmp
               mountPath: /tmp
             - name: camunda

--- a/charts/zeebe-benchmark/test/golden/operate-service.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/operate-service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.5.4"
+    app.kubernetes.io/version: "SNAPSHOT"
   annotations:
 spec:
   type: ClusterIP
@@ -19,6 +19,10 @@ spec:
     - port: 80
       name: http
       targetPort: 8080
+      protocol: TCP
+    - port: 9600
+      name: management
+      targetPort: 9600
       protocol: TCP
   selector:
     app: camunda-platform


### PR DESCRIPTION
The version we used before was always lagging behind, and the last released minor. This doesn't work with recent changes we did with the mono-repo and in general that we want to test in our benchmarks. 

For example, previous benchmarks failed, due to wrong configs in the old Helm chart version, as the Operate configuration has changed with the mono repo, see investigation [here](https://github.com/camunda/camunda/issues/21033#issuecomment-2288476572) 

See related discussion also [here](https://github.com/camunda/camunda-platform-helm/pull/2223#issuecomment-2289157601) 

closes https://github.com/camunda/camunda/issues/21033