### PR TITLE
Enable write rate limits for the benchmarks.

### DIFF
--- a/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/benchmark-config.golden.yaml
@@ -17,5 +17,7 @@ data:
     zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
     zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: yyyy-MM-dd_HH
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 4000
     zeebe.gateway.monitoring.enabled: "true"
     zeebe.gateway.threads.managementThreads: "1"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -68,7 +68,7 @@ timer:
   # Timer.rate defines with which rate process instances with timers should be created
   rate: 25
 
-# LeaderBalanacing configuration for the auto rebalancing feature, which allows to rebalance periodically the zeebe cluster
+# LeaderBalancing configuration for the auto rebalancing feature, which allows to rebalance periodically the zeebe cluster
 # For more details see https://docs.camunda.io/docs/self-managed/zeebe-deployment/operations/rebalancing/
 leaderBalancing:
   # LeaderBalancing.enabled if true, enables the auto leader rebalancing
@@ -92,6 +92,9 @@ zeebe:
     # Configure index suffix with hour pattern, so we create every hour a new index
     # such that ILM can clean it up quickly
     zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: "yyyy-MM-dd_HH"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 4000
   # Zeebe.profiling configuration for pyroscope profiling
   profiling:
     # Zeebe.profiling.enabled if true, enables the pyroscope profiling


### PR DESCRIPTION
This PR enables write rate limits for benchmarks so that we can visualize flow control metrics in benchmarks.
The limit was set as 4000, as its higher than the maximum processed rate observed in benchmarks, while still being close to this value. [See discussion.](https://github.com/camunda/camunda/issues/21324)

Relates https://github.com/camunda/camunda/issues/21324