### PR TITLE
Extend starter values to onfigure starter app

### DIFF
--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -27,9 +27,23 @@ spec:
                 -Dapp.starter.rate={{ .Values.starter.rate }}
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
+                {{- if .Values.starter.bpmnXmlPath }}
+                -Dapp.starter.bpmnXmlPath= {{ .Values.starter.bpmnXmlPath | quote }}
+                {{- end }}
+                {{- if .Values.starter.extraResources }}
+                -Dapp.starter.extraBpmnModels=[{{ join "," .Values.starter.extraResources }}]
+                {{- end }}
+                {{- if .Values.starter.businessKey }}
+                -Dapp.starter.businessKey={{ .Values.starter.businessKey | quote }}
+                {{- end }}
+                {{- if .Values.starter.payloadPath }}
+                -Dapp.starter.payloadPath={{ .Values.starter.payloadPath | quote }}
+                {{- end }}
                 -XX:+HeapDumpOnOutOfMemoryError
+            {{- if .Values.starter.logLevel }}
             - name: LOG_LEVEL
-              value: "warn"
+              value: {{ .Values.starter.logLevel | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/starter-extended.golden.yaml
@@ -29,12 +29,13 @@ spec:
                 -Dapp.starter.rate=150
                 -Dapp.starter.durationLimit=0
                 -Dzeebe.client.requestTimeout=62000
-                -Dapp.starter.bpmnXmlPath= "bpmn/one_task.bpmn"
-                -Dapp.starter.businessKey="businessKey"
-                -Dapp.starter.payloadPath="bpmn/big_payload.json"
+                -Dapp.starter.bpmnXmlPath= "bpmn/real.bpmn"
+                -Dapp.starter.extraBpmnModels=[bpmn/extra.bpmn,bpmn/extra.dmn]
+                -Dapp.starter.businessKey="customerId"
+                -Dapp.starter.payloadPath="empty.json"
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
-              value: "WARN"
+              value: "INFO"
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden_test.go
+++ b/charts/zeebe-benchmark/test/golden_test.go
@@ -52,3 +52,29 @@ func TestGoldenWorkers(t *testing.T) {
 		})
 	}
 }
+
+func TestGoldenExtendedStarter(t *testing.T) {
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+	templateNames := []string{"starter"}
+
+	values := map[string]string{
+		"starter.logLevel":          "INFO",
+		"starter.payloadPath":       "empty.json",
+		"starter.bpmnXmlPath":       "bpmn/real.bpmn",
+		"starter.extraResources[0]": "bpmn/extra.bpmn",
+		"starter.extraResources[1]": "bpmn/extra.dmn",
+		"starter.businessKey":       "customerId",
+	}
+
+	for _, name := range templateNames {
+		suite.Run(t, &golden.TemplateGoldenTest{
+			ChartPath:      chartPath,
+			Release:        "benchmark-test",
+			Namespace:      "benchmark-" + strings.ToLower(random.UniqueId()),
+			GoldenFileName: name + "-extended",
+			Templates:      []string{"templates/" + name + ".yaml"},
+			SetValues:      values,
+		})
+	}
+}

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -101,6 +101,18 @@ starter:
   replicas: 1
   # Starter.rate defines with which rate process instances should be created by the starter
   rate: 150
+  # Starter.logLevel defines the logging level for the benchmark starter
+  logLevel: "WARN"
+  # Starter.payloadPath defines the path (inside the starter app) to the payload resource
+  # that should be used to create the corresponding process instance
+  payloadPath: "bpmn/big_payload.json"
+  # Starter.bpmnXmlPath defines the path (inside the starter app) to the main bpmn XML resource that should be deployed
+  bpmnXmlPath: "bpmn/one_task.bpmn"
+  # Starter.extraBpmnModels can be used to specify paths (inside the starter app) to extra resources that should be deployed
+  extraResources: []
+  # Starter.businessKey can be used to specify a businessKey variable, inside a unique identifier is stored for
+  # each created process instance
+  businessKey: "businessKey"
 
 # Publisher configuration for the to be deployed publisher application
 publisher:


### PR DESCRIPTION
Extend starter values, such that we can better configure the starter application.

The new configuration allows configuring:

 * The bpmnModelPath which is used to read the main process model that is deployed on start-up
 * The extra bpmn models that can be configured to deploy additional models
 * The business key, to add a unique identifier for each process instance with a given var name
 * The payload path to configure with which payload the instances are created
 * The log level for the starter application