### PR TITLE
fix: use larger disks to avoid throttling

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
@@ -244,4 +244,4 @@ spec:
         storageClassName: ssd
         resources:
           requests:
-            storage: "32Gi"
+            storage: "48Gi"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -313,7 +313,7 @@ camunda-platform:
     # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
     pvcAccessMode: [ "ReadWriteOnce" ]
     # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
-    pvcSize: 32Gi
+    pvcSize: 48Gi
     # PvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD.
     pvcStorageClassName: ssd
 


### PR DESCRIPTION
As we saw in https://github.com/camunda/camunda/issues/21758, a 32 GiB disk is slightly too small for our default workload.