### PR TITLE
fix: use previously completionDelay default

### DIFF
--- a/charts/zeebe-benchmark/test/golden/workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/workers.golden.yaml
@@ -33,7 +33,7 @@ spec:
                 -Dapp.worker.workerName="benchmark"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/big_payload.json"
-                -Dapp.worker.completionDelay=300ms
+                -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -56,7 +56,7 @@ workers:
     # that should be used to complete the corresponding jobs
     payloadPath: "bpmn/big_payload.json"
     # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
-    completionDelay: 300ms
+    completionDelay: 50ms
     # Workers.benchmark.logLevel defines the logging level for the benchmark worker
     logLevel: "WARN"
     # Workers.benchmark.resources defines the resources for the benchmark worker


### PR DESCRIPTION
Previously we had a default of 50ms instead of 300ms, increasing the delay was causing to decrease in expected throughput.


Slack thread https://camunda.slack.com/archives/C037RS2JHB8/p1726581128553019