### PR TITLE
Improve worker configs

### DIFF
--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -34,7 +34,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "customer_notification"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -62,7 +62,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "extract_data_from_document"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -87,7 +87,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 3
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "dispute_process_request_proof_from_vendor"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -116,7 +116,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "dispute_process_request_get_vendor_info"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -142,7 +142,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 3
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "refunding"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -167,7 +167,7 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 60
+    capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "inform_about_successful_claim"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource

--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -85,7 +85,7 @@ workers:
   # Request proof from vendor
   dispute-process-request-proof-from-vendor:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
-    replicas: 3
+    replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
     capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
@@ -140,7 +140,7 @@ workers:
   # Refund payment
   refunding:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
-    replicas: 3
+    replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
     capacity: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker


### PR DESCRIPTION
Improve the worker configuration (benchmark results see [here](https://github.com/camunda/camunda/pull/22411#issuecomment-2357619085))

1. Most of the workers have a completion delay of 300ms, and per default 10 threads.
   This means per second they are able to complete ~30 in one second. As
   the timeout is calculated based on the completion delay (times 6 = 1800 ms). We
   have a high chance that jobs time out until we reach them.
   *  Reducing the capacity should remove this risk or reduce the chance.
2. Scale down workers. To reduce load on the cluster and smooth out the throughput and reduce failures, especially job time outs we have to reduce the worker pods. Proved in a benchmark see https://github.com/camunda/camunda/pull/22411#issuecomment-2357619085