### PR TITLE
Remove worker's repeated completion delay, and only add this if not set.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ For an example see [test/golden_test.go](charts/zeebe-benchmark/test/golden_test
 
 If the complete manifest can be enabled by a toggle, we also write a golden file test. This test is part of `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename we have in the sub-chart `templates` dir. For example, the prometheus [servicemonitor](charts/camunda-platform/templates/service-monitor.yaml) can be enabled by a toggle. This means we write a golden file test in [servicemonitor_test.go](charts/camunda-platform/test/servicemonitor_test.go).
 
-In order to generate the golden files run `go.test-with-updated-golden-files` on the root level of the repository. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should also be named related to the manifest.
+In order to generate the golden files run `go.test-golden-updated` on the root level of the repository. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should also be named related to the manifest.
 
 ##### Properties Test
 

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -34,16 +34,17 @@ spec:
                 -Dapp.worker.capacity={{ $worker.capacity }}
                 {{- end }}
                 -Dapp.worker.pollingDelay=1ms
+                {{- if $worker.completionDelay }}
+                -Dapp.worker.completionDelay={{ $worker.completionDelay }}
+                {{- else }}
                 -Dapp.worker.completionDelay=50ms
+                {{- end }}
                 -Dapp.worker.workerName={{ $workerName | quote }}
                 {{- if $worker.jobType }}
                 -Dapp.worker.jobType={{ $worker.jobType | quote }}
                 {{- end }}
                 {{- if $worker.payloadPath }}
                 -Dapp.worker.payloadPath={{ $worker.payloadPath | quote }}
-                {{- end}}
-                {{- if $worker.completionDelay }}
-                -Dapp.worker.completionDelay={{ $worker.completionDelay }}
                 {{- end}}
                 {{- if $worker.message }}
                 -Dapp.worker.sendMessage=true

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
@@ -33,7 +33,6 @@ spec:
                 -Dapp.worker.workerName="benchmark"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/big_payload.json"
-                -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
@@ -33,7 +33,6 @@ spec:
                 -Dapp.worker.workerName="benchmark"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/big_payload.json"
-                -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"

--- a/charts/zeebe-benchmark/test/golden/workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/workers.golden.yaml
@@ -33,7 +33,6 @@ spec:
                 -Dapp.worker.workerName="benchmark"
                 -Dapp.worker.jobType="benchmark-task"
                 -Dapp.worker.payloadPath="bpmn/big_payload.json"
-                -Dapp.worker.completionDelay=50ms
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"


### PR DESCRIPTION
With the previous worker version if we set the completion deplay, it would add both of them as seen on the medic [benchmark  of week 39](https://camunda.slack.com/archives/C05DH1F5TAR/p1727278288428469?thread_ts=1727254928.222029&cid=C05DH1F5TAR), and possibly pick the last read value which caused some issues and confusion. This way we only add the completion delay if not set.