### PR TITLE
Fix realistic benchmark

### DIFF
--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -33,6 +33,9 @@ spec:
                 {{- if $worker.capacity }}
                 -Dapp.worker.capacity={{ $worker.capacity }}
                 {{- end }}
+                {{- if $worker.threads }}
+                -Dapp.worker.threads={{ $worker.threads }}
+                {{- end }}
                 -Dapp.worker.pollingDelay=1ms
                 {{- if $worker.completionDelay }}
                 -Dapp.worker.completionDelay={{ $worker.completionDelay }}

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
@@ -28,6 +28,7 @@ spec:
                 -Dapp.tls=true
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
                 -Dapp.worker.workerName="benchmark"

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
@@ -28,6 +28,7 @@ spec:
                 -Dapp.tls=true
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
                 -Dapp.worker.workerName="benchmark"

--- a/charts/zeebe-benchmark/test/golden/workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/workers.golden.yaml
@@ -28,6 +28,7 @@ spec:
                 -Dapp.brokerUrl=benchmark-test-zeebe-gateway:26500
                 -Dzeebe.client.requestTimeout=62000
                 -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
                 -Dapp.worker.pollingDelay=1ms
                 -Dapp.worker.completionDelay=50ms
                 -Dapp.worker.workerName="benchmark"

--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -87,7 +87,9 @@ workers:
     # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
-    capacity: 30
+    capacity: 60
+    # Workers.benchmark.threads defines how many threads the worker can use to work on jobs
+    threads: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "dispute_process_request_proof_from_vendor"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
@@ -143,6 +145,8 @@ workers:
     replicas: 1
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
     capacity: 30
+    # Workers.benchmark.threads defines how many threads the worker can use to work on jobs
+    threads: 30
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "refunding"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -85,6 +85,8 @@ workers:
     replicas: 3
     # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
     capacity: 60
+    # Workers.benchmark.threads defines how many threads the worker can use to work on jobs
+    threads: 10
     # Workers.benchmark.jobType defines the job type which should be used by the worker
     jobType: "benchmark-task"
     # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource


### PR DESCRIPTION
## Details

Our realistic benchmarks had some issues with keeping up with the load (when using the realistic payload). Job completions where lower than creations, causing a slow increase of state.

Reported also in slack https://camunda.slack.com/archives/C037RS2JHB8/p1730111585816089

Jobs seem to be not completed fast enough, but there seem to be enough in buffer

![enough-im-buffer](https://github.com/user-attachments/assets/70325d73-536c-42f2-a821-f61161653d82)

### Left overs

Looking into Operate of one of these benchmarks we can clearly see that we have many instances left.

![general](https://github.com/user-attachments/assets/87463423-b1e3-479b-843c-95765f6b3319)

Look at the process we see where most token stay.

![overview-process](https://github.com/user-attachments/assets/4dc668d8-826f-43cd-978f-b323b9d0955c)


![details-request-proof](https://github.com/user-attachments/assets/13240894-3458-4c5b-8fb5-bd0df9e8d05a)

After fixing the first part it went stuck in the refund job (so we had to adjust configs for both).

![refund](https://github.com/user-attachments/assets/d8db35a9-096f-45ab-ad68-ebc707c66123)

## Benchmark with fix

After fixing the benchmark I have run a benchmark over night. We can see that the completion and creation is the same. Even for the Process Instances! This means we will not have any left overs anymore.

![now-stable-completion](https://github.com/user-attachments/assets/e75136b2-fd4b-4810-ae38-135a6b803d20)

We can see that the snapshot size stabilizes around 25mb. This is because of buffered messages.

![now-snapshot](https://github.com/user-attachments/assets/72e6c687-a2d6-4e9b-9fba-6abf5c059ec3)

The performance of this benchmark is quite stable and high


![now-stable-general](https://github.com/user-attachments/assets/96b5cef8-736b-409b-9179-bb621e95f673)
