### PR TITLE
fix: increase cpu zeebe limit to 1.7 while keeping cpu-request at 1.35

### DIFF
--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -237,7 +237,7 @@ camunda-platform:
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
     resources:
       limits:
-        cpu: 1350m
+        cpu: 1700m
         memory: 4Gi
       requests:
         cpu: 1350m


### PR DESCRIPTION
With the previous limit throttling was very high (even > 80%). 
With this limit, there is less backpressure & less timeouts which reduce the cpu usage to around 1 (from 1.2).

For reference this is the benchmark run:
[Grafana](https://grafana.dev.zeebe.io/d/ce1xu7mewjpj4c/zeebe-temp-cs?orgId=1&from=1730815673277&to=1730821316682&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=cs-batch-size-32&var-pod=All&var-partition=All)

You can clearly see the difference in throttling & cpu usage before & after the restart