### PR TITLE
fix: increase zeebe cpu limit to 1.7 in default benchmark

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
@@ -177,7 +177,7 @@ spec:
               cpu: 1350m
               memory: 4Gi
             requests:
-              cpu: 1350m
+              cpu: 1700m
               memory: 4Gi
           volumeMounts:
             - name: config

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -336,7 +336,7 @@ camunda-platform:
         cpu: 1350m
         memory: 4Gi
       requests:
-        cpu: 1350m
+        cpu: 1700m
         memory: 4Gi
 
     nodeSelector:


### PR DESCRIPTION
Change the cpu limits in the default benchmark to match the limits  in the realistic one