### PR TITLE
fix: cpu request & limits were inverted in default benchmark

### DIFF
--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
@@ -174,10 +174,10 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 1350m
+              cpu: 1700m
               memory: 4Gi
             requests:
-              cpu: 1700m
+              cpu: 1350m
               memory: 4Gi
           volumeMounts:
             - name: config

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -333,10 +333,10 @@ camunda-platform:
     # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
     resources:
       limits:
-        cpu: 1350m
+        cpu: 1700m
         memory: 4Gi
       requests:
-        cpu: 1700m
+        cpu: 1350m
         memory: 4Gi
 
     nodeSelector:


### PR DESCRIPTION
cpu requests & limits were inverted by mistake