### PR TITLE
Enable Camunda Exporter in benchmarks and disable importer in realistic benchmarks

### DIFF
--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -10,7 +10,7 @@ sources:
 dependencies:
   - name: camunda-platform
     repository: "oci://ghcr.io/camunda/helm"
-    version: "0.0.0-rc-8.6"
+    version: "0.0.0-12.0.0-alpha1"
     condition: "camunda.enabled"
   - name: prometheus-elasticsearch-exporter
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-configmap.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-configmap.golden.yaml
@@ -27,6 +27,17 @@ data:
                 enabled: true
                 minimumAge: "10m"
                 policyName: "zeebe-record-retention-policy"
+          CamundaExporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: elasticsearch
+                url: "http://benchmark-test-elasticsearch:9200"
+              retention:
+                enabled: true
+                minimumAge: "10m"
+                policyName: "zeebe-record-retention-policy"
+              createSchema: true
         gateway:
           enable: true
           network:

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-gateway-deployment.golden.yaml
@@ -37,7 +37,7 @@ spec:
         app.kubernetes.io/component: zeebe-gateway
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: aa5fd448aec5e0866ac5acf384418a4ec6fe804fdb7b8a0fa9094575cc03e9e6
+        checksum/config: 5f4fd8148098be186ae2347fc681e161a687eea366b1dd43133b9dd7036fdcf4
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/c8-zeebe-statefulset.golden.yaml
@@ -38,7 +38,7 @@ spec:
         app.kubernetes.io/component: zeebe-broker
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: 499bbd401adeb5d710e43685f146335086024a4b748c87d9256618b1423f97b1
+        checksum/config: 4e7d66ef2c5cc5b5153ce41dd3b77c26d1ebea04c443bb81cbb8ec00a96462b1
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/test/golden/operate-deployment.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/operate-deployment.golden.yaml
@@ -37,7 +37,7 @@ spec:
         app.kubernetes.io/component: operate
         app.kubernetes.io/version: "SNAPSHOT"
       annotations:
-        checksum/config: b80d0970df74f955b54c4e039b14f58098da5d676fafcaed25fbaff900013453
+        checksum/config: ceb62825f95f54158a4e89ebd5a4e5d6fc000b670795273e68a685be017246b6
     spec:
       imagePullSecrets:
         []

--- a/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+++ b/charts/zeebe-benchmark/values-realistic-benchmark.yaml
@@ -275,6 +275,9 @@ camunda-platform:
       limits:
         cpu: 2000m
         memory: 2Gi
+    env:
+      - name: CAMUNDA_OPERATE_IMPORTERENABLED
+        value: "false"
 
   # ELASTIC
   elasticsearch:


### PR DESCRIPTION
## Description

To have an early integration of the new planned Camunda Exporter with the Zeebe system and other components, update the benchmark helm charts to alpha1 and disable importer (to validate this works without importers).