### PR TITLE
Increase ES disk size for the benchmarks.

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -525,7 +525,7 @@ camunda-platform:
         # Persistent Volume Storage Class
         storageClass: "ssd"
         # Persistent Volume Size
-        size: 32Gi
+        size: 64Gi
         # Persistent Volume Access Modes
         accessModes: [ "ReadWriteOnce" ]
 

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -525,7 +525,7 @@ camunda-platform:
         # Persistent Volume Storage Class
         storageClass: "ssd"
         # Persistent Volume Size
-        size: 16Gi
+        size: 32Gi
         # Persistent Volume Access Modes
         accessModes: [ "ReadWriteOnce" ]
 


### PR DESCRIPTION
Increases the disk size from 16 to 32GB in ES.

This commit was separated from https://github.com/zeebe-io/benchmark-helm/pull/213 due to urgency of increasing the resources. 
