### PR TITLE
feat: configure gcs backup store by default

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -347,6 +347,14 @@ camunda-platform:
             name: zeebe-config
             key: java-opts
             optional: true
+      - name: ZEEBE_BROKER_DATA_BACKUP_STORE
+        value: gcs
+      - name: ZEEBE_BROKER_DATA_BACKUP_GCS_BUCKETNAME
+        value: zeebe-load-test-backups
+      - name: ZEEBE_BROKER_DATA_BACKUP_GCS_BASEPATH
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
 
   ############################################
   ## @section Elasticsearch Parameters


### PR DESCRIPTION
This works because I manually created a policy to grant all pods in the `zeebe-cluster` kubernetes cluster the `storage.objectAdmin` role:

```bash
$ gcloud projects add-iam-policy-binding projects/zeebe-io \
                         --role=roles/storage.objectAdmin \
                         --member=principalSet://iam.googleapis.com/projects/628707732411/locations/global/workloadIdentityPools/zeebe-io.svc.id.goog/kubernetes.cluster/https://container.googleapis.com/v1/projects/zeebe-io/locations/europe-west1-b/clusters/zeebe-cluster \
                         --condition=None
```

Ideally, we'd restrict it further to specific buckets and prefixes but I think it's good enough as a start.