### PR TITLE
Fix benchmark to run against saas. 

### DIFF
--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -91,7 +91,10 @@ helm install PREFIX-saas-load-test zeebe-benchmark/zeebe-benchmark \
   --set saas.credentials.clientId="$ZEEBE_CLIENT_ID" \
   --set saas.credentials.clientSecret="$ZEEBE_CLIENT_SECRET" \
   --set saas.credentials.zeebeRestAddress="$ZEEBE_REST_ADDRESS" \
-  --set saas.credentials.authServer="$ZEEBE_AUTHORIZATION_SERVER_URL"
+  --set saas.credentials.authServer="$ZEEBE_AUTHORIZATION_SERVER_URL" \
+  --set saas.credentials.authType="OAUTH" \
+  --set saas.credentials.zeebeGrpcAddress="$ZEEBE_GRPC_ADDRESS" \
+  --set saas.credentials.authorizationAudience="$ZEEBE_TOKEN_AUDIENCE"
 ```
 
 

--- a/charts/zeebe-benchmark/README.md
+++ b/charts/zeebe-benchmark/README.md
@@ -90,7 +90,7 @@ helm install PREFIX-saas-load-test zeebe-benchmark/zeebe-benchmark \
   --set saas.enabled=true \
   --set saas.credentials.clientId="$ZEEBE_CLIENT_ID" \
   --set saas.credentials.clientSecret="$ZEEBE_CLIENT_SECRET" \
-  --set saas.credentials.zeebeAddress="$ZEEBE_ADDRESS" \
+  --set saas.credentials.zeebeRestAddress="$ZEEBE_REST_ADDRESS" \
   --set saas.credentials.authServer="$ZEEBE_AUTHORIZATION_SERVER_URL"
 ```
 

--- a/charts/zeebe-benchmark/templates/credentials.yaml
+++ b/charts/zeebe-benchmark/templates/credentials.yaml
@@ -9,4 +9,7 @@ stringData:
   clientSecret: {{ .Values.saas.credentials.clientSecret }}
   zeebeAddress: {{ .Values.saas.credentials.zeebeAddress }}
   authServer: {{ .Values.saas.credentials.authServer }}
+  authType: {{ .Values.saas.credentials.authType }}
+  zeebeGrpcAddress: {{- if .Values.saas.credentials.zeebeGrpcAddress }} {{ .Values.saas.credentials.zeebeGrpcAddress }}{{- end }}
+  authorizationAudience: {{ .Values.saas.credentials.authorizationAudience }}
 {{- end }}

--- a/charts/zeebe-benchmark/templates/credentials.yaml
+++ b/charts/zeebe-benchmark/templates/credentials.yaml
@@ -7,7 +7,7 @@ type: Opaque
 stringData:
   clientId: {{ .Values.saas.credentials.clientId }}
   clientSecret: {{ .Values.saas.credentials.clientSecret }}
-  zeebeAddress: {{ .Values.saas.credentials.zeebeAddress }}
+  zeebeRestAddress: {{ .Values.saas.credentials.zeebeRestAddress }}
   authServer: {{ .Values.saas.credentials.authServer }}
   authType: {{ .Values.saas.credentials.authType }}
   zeebeGrpcAddress: {{- if .Values.saas.credentials.zeebeGrpcAddress }} {{ .Values.saas.credentials.zeebeGrpcAddress }}{{- end }}

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -89,8 +89,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -58,7 +58,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/zeebe-benchmark/templates/starter.yaml
+++ b/charts/zeebe-benchmark/templates/starter.yaml
@@ -54,7 +54,7 @@ spec:
               value: {{ .Values.starter.logLevel | quote }}
             {{- end }}
             {{- if $.Values.saas.enabled }}
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
@@ -74,6 +74,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
             {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -97,8 +97,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
             {{- end }}
           {{- if $worker.resources }}
           resources:

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -62,7 +62,7 @@ spec:
               value: {{ $worker.logLevel | quote }}
             {{- end }}
             {{- if $.Values.saas.enabled }}
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
@@ -82,6 +82,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zeebe-benchmark.credentials-name" $ }}
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
             {{- end }}
           {{- if $worker.resources }}
           resources:

--- a/charts/zeebe-benchmark/templates/workers.yaml
+++ b/charts/zeebe-benchmark/templates/workers.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "zeebe-benchmark.credentials-name" $ }}
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-credentials.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-credentials.golden.yaml
@@ -10,3 +10,6 @@ stringData:
   clientSecret: clientSecret
   zeebeAddress: zeebeAddress
   authServer: authServer
+  authType: OAUTH
+  zeebeGrpcAddress:
+  authorizationAudience:

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-credentials.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-credentials.golden.yaml
@@ -8,7 +8,7 @@ type: Opaque
 stringData:
   clientId: clientId
   clientSecret: clientSecret
-  zeebeAddress: zeebeAddress
+  zeebeRestAddress: zeebeRestAddress
   authServer: authServer
   authType: OAUTH
   zeebeGrpcAddress:

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
@@ -37,7 +37,7 @@ spec:
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: benchmark-test-credentials
@@ -57,6 +57,23 @@ spec:
                 secretKeyRef:
                   name: benchmark-test-credentials
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-starter.golden.yaml
@@ -41,7 +41,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: benchmark-test-credentials
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -72,8 +72,6 @@ spec:
                 secretKeyRef:
                   name: benchmark-test-credentials
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
@@ -38,7 +38,7 @@ spec:
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: benchmark-test-credentials
@@ -58,6 +58,23 @@ spec:
                 secretKeyRef:
                   name: benchmark-test-credentials
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: benchmark-test-credentials
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
           resources:
             limits:
               cpu: 500m

--- a/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-credentials-workers.golden.yaml
@@ -42,7 +42,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: benchmark-test-credentials
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -73,8 +73,6 @@ spec:
                 secretKeyRef:
                   name: benchmark-test-credentials
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
           resources:
             limits:
               cpu: 500m

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
@@ -37,7 +37,7 @@ spec:
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: secret-name
@@ -57,6 +57,23 @@ spec:
                 secretKeyRef:
                   name: secret-name
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-starter.golden.yaml
@@ -41,7 +41,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: secret-name
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -72,8 +72,6 @@ spec:
                 secretKeyRef:
                   name: secret-name
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
           envFrom:
             - configMapRef:
                 name: starter-config

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
@@ -38,7 +38,7 @@ spec:
                 -XX:+HeapDumpOnOutOfMemoryError
             - name: LOG_LEVEL
               value: "WARN"
-            - name: ZEEBE_ADDRESS
+            - name: ZEEBE_REST_ADDRESS
               valueFrom:
                 secretKeyRef:
                   name: secret-name
@@ -58,6 +58,23 @@ spec:
                 secretKeyRef:
                   name: secret-name
                   key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: secret-name
+                  key: zeebeGrpcAddress
+            - name: TLS
+              value: "true"
           resources:
             limits:
               cpu: 500m

--- a/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
+++ b/charts/zeebe-benchmark/test/golden/golden-existing-credential-secret-workers.golden.yaml
@@ -42,7 +42,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: secret-name
-                  key: zeebeAddress
+                  key: zeebeRestAddress
             - name: ZEEBE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -73,8 +73,6 @@ spec:
                 secretKeyRef:
                   name: secret-name
                   key: zeebeGrpcAddress
-            - name: TLS
-              value: "true"
           resources:
             limits:
               cpu: 500m

--- a/charts/zeebe-benchmark/test/saas_configuration_test.go
+++ b/charts/zeebe-benchmark/test/saas_configuration_test.go
@@ -32,7 +32,7 @@ func TestGoldenCredentials(t *testing.T) {
 				"saas.credentials.clientId":     "clientId",
 				"saas.credentials.clientSecret": "clientSecret",
 				"saas.credentials.authServer":   "authServer",
-				"saas.credentials.zeebeAddress": "zeebeAddress",
+				"saas.credentials.zeebeRestAddress": "zeebeRestAddress",
 			},
 		})
 	}

--- a/charts/zeebe-benchmark/test/saas_configuration_test.go
+++ b/charts/zeebe-benchmark/test/saas_configuration_test.go
@@ -28,10 +28,10 @@ func TestGoldenCredentials(t *testing.T) {
 			GoldenFileName: "golden-credentials-" + name,
 			Templates:      []string{"templates/" + name + ".yaml"},
 			SetValues: map[string]string{
-				"saas.enabled":                  "true",
-				"saas.credentials.clientId":     "clientId",
-				"saas.credentials.clientSecret": "clientSecret",
-				"saas.credentials.authServer":   "authServer",
+				"saas.enabled":                      "true",
+				"saas.credentials.clientId":         "clientId",
+				"saas.credentials.clientSecret":     "clientSecret",
+				"saas.credentials.authServer":       "authServer",
 				"saas.credentials.zeebeRestAddress": "zeebeRestAddress",
 			},
 		})

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -73,10 +73,17 @@ saas:
     clientId: ""
     # Saas.credentials.clientSecret to define the clientSecret to connect
     clientSecret: ""
-    # Saas.credentials.zeebeAddress to define the address of the cluster (including port)
+    # Saas.credentials.zeebeAddress to define the rest address of the cluster (including port)
     zeebeAddress:
     # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
     authServer: "https://login.cloud.ultrawombat.com/oauth/token"
+    # Saas.credentials.authType to define the authentication type for the starter and workers
+    authType: "OAUTH"
+    # Saas.credentials.zeebeGrpcAddress to define the grpc address of the cluster
+    zeebeGrpcAddress: ""
+    # Saas.credentials.authorizationAudience to define the auth audience of the cluster
+    authorizationAudience: ""
+
 
 # Workers configuration for the to be deployed worker application
 #        => New way to deploy workers <=

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -65,7 +65,7 @@ saas:
     # stringData:
     #   clientId: hH55UFivfw-bbHAuPwN545oyv8tTdW0z
     #   clientSecret: xtHQB.zBLcQrw4GaP0k_ci~ePjbD8qVlYaFKNo__2a7ZJxL-DAVVHepq~X9elPRb
-    #   zeebeAddress: e314a337-a462-4988-a3be-d1f2e153e034.zeebe.ultrawombat.com:443
+    #   zeebeRestAddress: e314a337-a462-4988-a3be-d1f2e153e034.zeebe.ultrawombat.com:443
     #   authServer: https://login.cloud.ultrawombat.com/oauth/token
     existingSecret:
 
@@ -73,8 +73,8 @@ saas:
     clientId: ""
     # Saas.credentials.clientSecret to define the clientSecret to connect
     clientSecret: ""
-    # Saas.credentials.zeebeAddress to define the rest address of the cluster (including port)
-    zeebeAddress:
+    # Saas.credentials.zeebeRestAddress to define the rest address of the cluster (including port)
+    zeebeRestAddress:
     # SaaS.credentials.authServer to define the authentication server to retrieve JWT tokens
     authServer: "https://login.cloud.ultrawombat.com/oauth/token"
     # Saas.credentials.authType to define the authentication type for the starter and workers


### PR DESCRIPTION
In conjunction with https://github.com/camunda/camunda/pull/39330 this PR fixes the issue of the starter and workers running against saas. For this now we also pass through the benchmark credentials the vars `ZEEBE_AUTH_TYPE`, `ZEEBE_TOKEN_AUDIENCE`, and `ZEEBE_GRPC_ADDRESS` only when we enable running against saas. 

Aditionally we rename the variable `ZEEBE_ADDRESS` to `ZEEBE_REST_ADDRESS` to be in line with the saas variables that we get from the saas client.
When enabling saas, we also enable `tls` and we pass it through the credentials.