### PR TITLE
fix: bump cpu limits to 3

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -368,10 +368,10 @@ camunda-platform:
         accessModes: ["ReadWriteOnce"]
       resources:
         requests:
-          cpu: 1
+          cpu: 2 
           memory: 3Gi
         limits:
-          cpu: 2
+          cpu: 3
           memory: 6Gi
     extraConfig:
       logger.org.elasticsearch.deprecation: "OFF"


### PR DESCRIPTION
ES now requires more CPU after we added 1 replica per shard. 
