### PR TITLE
Fix benchmarks after config changes

### DIFF
--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -216,6 +216,15 @@ zeebe:
           minimumAge: "70m" # Deprecated - use camunda.data.secondaryStorage.retention.minimumAge
           policyName: "camunda-retention-policy" # Deprecated - use camunda.data.secondaryStorage.elasticsearch.history.policyName
 
+      data:
+        secondaryStorage:
+          retention:
+            enabled: true
+            minimumAge: "70m"
+          elasticsearch:
+            history:
+              policyName: "camunda-retention-policy"
+
     #Metrics:
     camunda.flags.jfr.metrics: "true"
     # RocksDB memory limit setting, limits the overall RocksDB memory usage

--- a/charts/zeebe-benchmark/values.yaml
+++ b/charts/zeebe-benchmark/values.yaml
@@ -205,12 +205,17 @@ zeebe:
     camunda.tasklist.importerEnabled: "false"
     camunda.operate.importerEnabled: "false"
     camunda.operate.elasticsearch.numberOfShards: 3
+
     # Schema management has been moved out of exporter - to be bootstrap at start; once
-    camunda.database.retention.enabled: "true"
-    # 0s causes ILM to move data asap - it is normally the default
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-    camunda.database.retention.minimumAge: "70m"
-    camunda.database.retention.policyName: "camunda-retention-policy"
+    camunda:
+      database:
+        retention:
+          enabled: "true" # Deprecated - use camunda.data.secondaryStorage.retention.enabled
+          # 0s causes ILM to move data asap - it is normally the default
+          # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+          minimumAge: "70m" # Deprecated - use camunda.data.secondaryStorage.retention.minimumAge
+          policyName: "camunda-retention-policy" # Deprecated - use camunda.data.secondaryStorage.elasticsearch.history.policyName
+
     #Metrics:
     camunda.flags.jfr.metrics: "true"
     # RocksDB memory limit setting, limits the overall RocksDB memory usage


### PR DESCRIPTION
Some breaking changes were made in the configuration of secondary storage's retention policy.

> Error starting Tomcat context. Exception: org.springframework.beans.factory.UnsatisfiedDependencyException. Message: Error creating bean with name 'brokerBasedConfiguration' defined in URL [jar:file:/usr/local/camunda/lib/camunda-zeebe-8.9.0-SNAPSHOT.jar!/io/camunda/application/commons/configuration/BrokerBasedConfiguration.class]: Unsatisfied dependency expressed through constructor parameter 2: Error creating bean with name 'brokerBasedProperties' defined in io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride: Failed to instantiate [io.camunda.configuration.beans.BrokerBasedProperties]: Factory method 'brokerBasedProperties' threw exception with message: Ambiguous configuration. The value camunda.data.secondary-storage.retention.enabled=false conflicts with the values 'true' from the legacy properties camunda.database.retention.enabled, zeebe.broker.exporters.camundaexporter.args.history.retention.enabled

I left the old ones in, because I think otherwise we will run into problems when creating benchmarks of older versions, since these charts are not versioned (?).

See https://github.com/camunda/camunda-operator/pull/4694/files#diff-3afac6842228c7b15b5a0095bf473211963afbb8a2d48184261ad4075d9c61ad

