### PR TITLE
Deprecate helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+```sh
+######   #######  ######   ######   #######   #####      #     #######  #######  ######
+#     #  #        #     #  #     #  #        #     #    # #       #     #        #     #
+#     #  #        #     #  #     #  #        #         #   #      #     #        #     #
+#     #  #####    ######   ######   #####    #        #     #     #     #####    #     #
+#     #  #        #        #   #    #        #        #######     #     #        #     #
+#     #  #        #        #    #   #        #     #  #     #     #     #        #     #
+######   #######  #        #     #  #######   #####   #     #     #     #######  ######
+```
+
+> ![Important]
+> This Helm Chart has been deprecated, to set up load tests please make use of:
+>
+> * Camunda Platform Helm chart https://helm.camunda.io/
+> * Load test Helm chart https://camunda.github.io/camunda-load-tests-helm/
+>
+>
+> This chart is no longer maintained and will not receive updates or support.
+
 # Zeebe Benchmark Helm 
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 ######   #######  #        #     #  #######   #####   #     #     #     #######  ######
 ```
 
-> ![Important]
+> [!Important]
+> 
 > This Helm Chart has been deprecated, to set up load tests please make use of:
 >
 > * Camunda Platform Helm chart https://helm.camunda.io/

--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -4,6 +4,7 @@ description: A Helm chart for Zeebe benchmarks
 type: application
 version: 0.3.27
 appVersion: "8.2.5"
+deprecated: true
 sources:
   - https://github.com/camunda/zeebe-benchmark-helm
   - https://github.com/camunda/camunda

--- a/charts/zeebe-benchmark/Chart.yaml
+++ b/charts/zeebe-benchmark/Chart.yaml
@@ -17,9 +17,6 @@ dependencies:
     repository: "https://prometheus-community.github.io/helm-charts"
     version: 6.4.0
     condition: "prometheus-elasticsearch-exporter.enabled"
-maintainers:
-  - name: ChrisKujawa
-    email: christopher.zell@camunda.com
 annotations:
   artifacthub.io/links: |
     - name: Zeebe Repo

--- a/charts/zeebe-benchmark/templates/NOTES.txt
+++ b/charts/zeebe-benchmark/templates/NOTES.txt
@@ -13,7 +13,7 @@ This Helm Chart has been deprecated, to set up load tests please make use of:
  * Load test Helm chart https://camunda.github.io/camunda-load-tests-helm/
 
 
- This chart is no longer maintained and will not receive updates or support.
+This chart is no longer maintained and will not receive updates or support.
 
 # Zeebe Benchmark
 

--- a/charts/zeebe-benchmark/templates/NOTES.txt
+++ b/charts/zeebe-benchmark/templates/NOTES.txt
@@ -1,3 +1,20 @@
+ ######   #######  ######   ######   #######   #####      #     #######  #######  ######
+ #     #  #        #     #  #     #  #        #     #    # #       #     #        #     #
+ #     #  #        #     #  #     #  #        #         #   #      #     #        #     #
+ #     #  #####    ######   ######   #####    #        #     #     #     #####    #     #
+ #     #  #        #        #   #    #        #        #######     #     #        #     #
+ #     #  #        #        #    #   #        #     #  #     #     #     #        #     #
+ ######   #######  #        #     #  #######   #####   #     #     #     #######  ######
+
+
+This Helm Chart has been deprecated, to set up load tests please make use of:
+
+ * Camunda Platform Helm chart https://helm.camunda.io/
+ * Load test Helm chart https://camunda.github.io/camunda-load-tests-helm/
+
+
+ This chart is no longer maintained and will not receive updates or support.
+
 # Zeebe Benchmark
 
 Installed Zeebe cluster with:


### PR DESCRIPTION
## Description

This will deprecate our Benchmark helm chart, as this is obsolete and replaced by our new decoupled approach.


Using 

 * https://github.com/camunda/camunda-platform-helm
 * https://github.com/camunda/camunda-load-tests-helm

For example via: https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml


After this PR is merged. I will release a new version (which gets published as last artifact), afterwards I will archive the repo.

## Details

When installing the chart (after release) it will look like this:


```

NOTES:
######   #######  ######   ######   #######   #####      #     #######  #######  ######
 #     #  #        #     #  #     #  #        #     #    # #       #     #        #     #
 #     #  #        #     #  #     #  #        #         #   #      #     #        #     #
 #     #  #####    ######   ######   #####    #        #     #     #     #####    #     #
 #     #  #        #        #   #    #        #        #######     #     #        #     #
 #     #  #        #        #    #   #        #     #  #     #     #     #        #     #
 ######   #######  #        #     #  #######   #####   #     #     #     #######  ######


This Helm Chart has been deprecated, to set up load tests please make use of:

 * Camunda Platform Helm chart https://helm.camunda.io/
 * Load test Helm chart https://camunda.github.io/camunda-load-tests-helm/


 This chart is no longer maintained and will not receive updates or support.

# Zeebe Benchmark

Installed Zeebe cluster with:

 * 3 Brokers (camunda/camunda:SNAPSHOT)
 * Active profiles:


The benchmark is running with:

Global image: gcr.io/zeebe-io:SNAPSHOT

Starter:
 - bpmnXmlPath: bpmn/one_task.bpmn
 - businessKey: businessKey
 - extraResources: []
 - logLevel: WARN
 - payloadPath: bpmn/typical_payload.json
 - processId: benchmark
 - rate: 150
 - replicas: 1

Workers:
 - worker


Other:
 * Publisher replicas=0
 * Timer replicas=0
```